### PR TITLE
Replace symbol keys in fact value by strings.

### DIFF
--- a/lib/facter/meltdown.rb
+++ b/lib/facter/meltdown.rb
@@ -5,11 +5,11 @@ def convert_structure(json_array)
   json_array.each do |item|
     key = item['CVE']
     value = {
-      CVE:          key.gsub(%r{CVE-}, ''),
-      description:  item['NAME'],
-      vulnerable:   item['VULNERABLE'],
-      info: {
-        hardware:   item['INFOS'],
+      'CVE'         => key.gsub(%r{CVE-}, ''),
+      'description' => item['NAME'],
+      'vulnerable'  => item['VULNERABLE'],
+      'info'        => {
+        'hardware' => item['INFOS'],
       },
     }
     output[key] = value


### PR DESCRIPTION
The meltdown fact contains symbol keys.

Introduced in puppetlabs/marionette-collective#445 the Mcollective
yaml_facts plugin breaks if a Symbol is present in any facter output.

The meltdown facter contains Symbol keys and effectively breaks
filtering by facts in our mcollective setup:

E, [2018-04-16T12:55:32.655810+02:00 #30893] ERROR -- : yaml_facts.rb:35:in `rescue in block in load_facts_from_source' Failed to load yaml facts from /etc/puppetlabs/mcollective/generated-facts.yaml: Psych::DisallowedClass: Tried to load unspecified class: Symbol

While fixed in puppetlabs/marionette-collective#474, that's still
unreleased and it's probably still better to ensure the fact doesn't
break older versions.