### PR TITLE
Update to 27MAY spectre-meltdown-checker.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.9.3
+
+**Features**
+
+* Updated `spectre-meltdown-checker.sh` to latest v0.37+ (27MAY2018)
+* Includes Variant 3a (CVE-2018-3640) and Variant 4 (CVE-2018-3639)
+
 ## Release 0.9.2
 
 **Features**

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "timidri-meltdown",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "author": "Dimitri Tischenko & Kevin Reeuwijk",
   "summary": "Detect and remediate Meltdown / Spectre vulnerability",
   "license": "Apache-2.0",


### PR DESCRIPTION
Updates the linux SH script which brings two new CVE's: 

- CVE-2018-3640 aka Variant 3a
- CVE-2018-3639 aka Variant 4