### PR TITLE
Added the noprofile flag to powershell execution string

### DIFF
--- a/lib/facter/meltdown_win.rb
+++ b/lib/facter/meltdown_win.rb
@@ -12,6 +12,6 @@ Facter.add('meltdown') do
       'meltdown',
       'spectre-meltdown-checker.ps1',
     )
-    JSON.parse(Facter::Util::Resolution.exec("#{powershell} -ExecutionPolicy Unrestricted -File #{checker_script}"))
+    JSON.parse(Facter::Util::Resolution.exec("#{powershell} -noprofile -ExecutionPolicy Unrestricted -File #{checker_script}"))
   end
 end


### PR DESCRIPTION
Hi, ran into this problem on my newly created custom fact right now and so yours were suffering the same problem. We have a few Windows servers with custom profiles loaded into powershell, so when anything uses powershell and omitting the "-noprofile" flag, they get "some" unwanted data that messes things up. Simple change, add it to your project if you want to. I tested it on my specific system, worked great!