### PR TITLE
Spectre meltdown checker v0.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.9.6
+
+**Features**
+
+* Linux
+  * Changed parameters of linux_update and windows_update tasks from Enum to Boolean
+  * Updated `spectre-meltdown-checker.sh` to v0.42 (16AUG2019)
+  * Updated README with full list of detected vulnerabilities
+
 ## Release 0.9.5
 
 **Features**

--- a/README.md
+++ b/README.md
@@ -10,21 +10,53 @@
 
 ## Description
 
-This module detects whether your system is vulnerable for Meltdown (CVE-2017-5754), Spectre (CVE-2017-5753, CVE-2017-5715, CVE-2018-3640, CVE-2018-3639) and related vulnerabilities (CVE-2018-3615, CVE-2018-3620, CVE-2018-3646) [L1 terminal fault] aka 'Foreshadow & Foreshadow-NG'. It then offers some tasks and manifests which help remediate the vulnerability. On Windows it also detects CVE-2019-1125, aka SWAPGS.
+This module detects whether your system is vulnerable for Meltdown and Spectre.
+
+### Detection on Linux
+
+On Linux, the module detects the following vulnerabilities (listed in alphabetical order):
+
+* CVE-2017-5715 [branch target injection] aka 'Spectre Variant 2'
+* CVE-2017-5753 [bounds check bypass] aka 'Spectre Variant 1'
+* CVE-2017-5754 [rogue data cache load] aka 'Meltdown' aka 'Variant 3'
+* CVE-2018-12126 [microarchitectural store buffer data sampling (MSBDS)] aka 'Fallout'
+* CVE-2018-12127 [microarchitectural load port data sampling (MLPDS)] aka 'RIDL'
+* CVE-2018-12130 [microarchitectural fill buffer data sampling (MFBDS)] aka 'ZombieLoad'
+* CVE-2018-3615 [L1 terminal fault] aka 'Foreshadow (SGX)'
+* CVE-2018-3620 [L1 terminal fault] aka 'Foreshadow-NG (OS)'
+* CVE-2018-3639 [speculative store bypass] aka 'Variant 4'
+* CVE-2018-3640 [rogue system register read] aka 'Variant 3a'
+* CVE-2018-3646 [L1 terminal fault] aka 'Foreshadow-NG (VMM)'
+* CVE-2019-11091 [microarchitectural data sampling uncacheable memory (MDSUM)] aka 'RIDL'
+
+For Linux, the module uses the script ``spectre-meltdown-checker.sh`` by Stéphane Lesimple - see https://github.com/speed47/spectre-meltdown-checker - all credits to him for that awesome script.
+
+### Detection on Windows
+
+On Windows, the module detects the following vulnerabilities (listed in alphabetical order):
+
+* CVE-2017-5715 Spectre Variant 2 (Branch Target Injection)
+* CVE-2017-5753 Spectre Variant 1 (Bounds Check Bypass)
+* CVE-2017-5754 Spectre Variant 3 - also known as Meltdown (Rogue Data Cache Load)
+* CVE-2018-12126 Microarchitectural Store Buffer Data Sampling (MSBDS)
+* CVE-2018-12127 Microarchitectural Fill Buffer Data Sampling (MFBDS)
+* CVE-2018-12130 Microarchitectural Load Port Data Sampling (MLPDS)
+* CVE-2018-3620 Spectre Variant 'Foreshadow' (L1 Terminal Fault)
+* CVE-2018-3639 Spectre Variant 4 (Speculative Store Bypass)
+* CVE-2019-11091 Microarchitectural Data Sampling Uncacheable Memory (MDSUM)
+* CVE-2019-1125 Spectre variant 1 variant - SWAPGS
+
+For Windows, the module uses the SpeculationControl module for Powershell - see https://www.powershellgallery.com/packages/SpeculationControl/1.0.14 and the Get-WUInstall function from Michal Gajda - see https://github.com/noma4i/puppet-windows_updates. All credits to the authors for these awesome functions.
+
+### Usage Warnings
 
 *NOTE*: full remediation also requires patching your hardware and/or virtualization platforms. Please refer to specific instructions for your vendors and consider patches carefully before applying.
 
 *NOTE*: this module is provided in the hope it will be useful, but does not guarantee correct or complete detection or remediation of Meltdown / Spectre. Use it at your own discretion.
 
-The module uses some code created by others, which we'd like to recognize here:
-
-For Linux, the module uses the script ``spectre-meltdown-checker.sh`` by Stéphane Lesimple - see https://github.com/speed47/spectre-meltdown-checker - all credits to him for that awesome script.
-
-For Windows, the module uses the SpeculationControl module for Powershell - see https://www.powershellgallery.com/packages/SpeculationControl/1.0.14 and the Get-WUInstall function from Michal Gajda - see https://github.com/noma4i/puppet-windows_updates. All credits to them for these awesome functions.
-
 ## Setup
 
-To get information (facts) only, just install the module on the puppetmaster (either manually or by adding it to Puppetfile). During the next puppet run, all connected agents will receive meltdown's facts definitions and will send meltdown's facts back to the puppetmaster.
+To get information (fact) only, just install the module on the Puppetmaster (either manually or by adding it to Puppetfile). During the next Puppet run, all connected agents will receive meltdown's fact definition and will send meltdown's fact back to the puppetmaster.
 
 This module includes two manifests to aid in some prerequisites that you can manage with Puppet.
 
@@ -46,7 +78,7 @@ Ensures the registry entries are present that are needed to enable the Spectre &
 
 ### Facts
 
-meltdown provides the following facts:
+meltdown provides the following fact:
 
 #### meltdown
 

--- a/lib/meltdown/spectre-meltdown-checker.sh
+++ b/lib/meltdown/spectre-meltdown-checker.sh
@@ -1,4 +1,6 @@
 #! /bin/sh
+# SPDX-License-Identifier: GPL-3.0-only
+#
 # Spectre & Meltdown checker
 #
 # Check for the latest version at:
@@ -9,7 +11,7 @@
 #
 # Stephane Lesimple
 #
-VERSION='0.39+'
+VERSION='0.42'
 
 trap 'exit_cleanup' EXIT
 trap '_warn "interrupted, cleaning up..."; exit_cleanup; exit 1' INT
@@ -19,15 +21,17 @@ exit_cleanup()
 	[ -n "$dumped_config" ] && [ -f "$dumped_config" ] && rm -f "$dumped_config"
 	[ -n "$kerneltmp"     ] && [ -f "$kerneltmp"     ] && rm -f "$kerneltmp"
 	[ -n "$kerneltmp2"    ] && [ -f "$kerneltmp2"    ] && rm -f "$kerneltmp2"
+	[ -n "$mcedb_tmp"     ] && [ -f "$mcedb_tmp"     ] && rm -f "$mcedb_tmp"
 	[ "$mounted_debugfs" = 1 ] && umount /sys/kernel/debug 2>/dev/null
 	[ "$mounted_procfs"  = 1 ] && umount "$procfs" 2>/dev/null
 	[ "$insmod_cpuid"    = 1 ] && rmmod cpuid 2>/dev/null
 	[ "$insmod_msr"      = 1 ] && rmmod msr 2>/dev/null
 	[ "$kldload_cpuctl"  = 1 ] && kldunload cpuctl 2>/dev/null
+	[ "$kldload_vmm"     = 1 ] && kldunload vmm    2>/dev/null
 }
 
 # if we were git clone'd, adjust VERSION
-if [ -d "$(dirname "$0")/.git" ] && which git >/dev/null 2>&1; then
+if [ -d "$(dirname "$0")/.git" ] && command -v git >/dev/null 2>&1; then
 	describe=$(git -C "$(dirname "$0")" describe --tags --dirty 2>/dev/null)
 	[ -n "$describe" ] && VERSION=$(echo "$describe" | sed -e s/^v//)
 fi
@@ -58,6 +62,8 @@ show_usage()
 		--verbose, -v		increase verbosity level, possibly several times
 		--explain		produce an additional human-readable explanation of actions to take to mitigate a vulnerability
 		--paranoid		require IBPB to deem Variant 2 as mitigated
+					also require SMT disabled + unconditional L1D flush to deem Foreshadow-NG VMM as mitigated
+					also require SMT disabled to deem MDS vulnerabilities mitigated
 
 		--no-sysfs		don't use the /sys interface even if present [Linux]
 		--sysfs-only		only use the /sys interface, don't run our own checks [Linux]
@@ -66,14 +72,21 @@ show_usage()
 		--arch-prefix PREFIX	specify a prefix for cross-inspecting a kernel of a different arch, for example "aarch64-linux-gnu-",
 					so that invoked tools will be prefixed with this (i.e. aarch64-linux-gnu-objdump)
 		--batch text		produce machine readable output, this is the default if --batch is specified alone
+		--batch short		produce only one line with the vulnerabilities separated by spaces
 		--batch json		produce JSON output formatted for Puppet, Ansible, Chef...
 		--batch nrpe		produce machine readable output formatted for NRPE
 		--batch prometheus      produce output for consumption by prometheus-node-exporter
 
-		--variant [1,2,3,3a,4,l1tf]	specify which variant you'd like to check, by default all variants are checked,
+		--variant VARIANT	specify which variant you'd like to check, by default all variants are checked
+					VARIANT can be one of 1, 2, 3, 3a, 4, l1tf, msbds, mfbds, mlpds, mdsum
 					can be specified multiple times (e.g. --variant 2 --variant 3)
+		--cve [cve1,cve2,...]	specify which CVE you'd like to check, by default all supported CVEs are checked
 		--hw-only		only check for CPU information, don't check for any variant
 		--no-hw			skip CPU information and checks, if you're inspecting a kernel not to be run on this host
+		--vmm [auto,yes,no]	override the detection of the presence of a hypervisor (for CVE-2018-3646), default: auto
+		--update-mcedb		update our local copy of the CPU microcodes versions database (from the awesome MCExtractor project)
+		--update-builtin-mcedb	same as --update-mcedb but update builtin DB inside the script itself
+		--dump-mock-data	used to mimick a CPU on an other system, mainly used to help debugging this script
 
 	Return codes:
 		0 (not vulnerable), 2 (vulnerable), 3 (unknown), 255 (error)
@@ -125,35 +138,38 @@ opt_live_explicit=0
 opt_live=1
 opt_no_color=0
 opt_batch=0
-opt_batch_format="text"
+opt_batch_format='text'
 opt_verbose=1
-opt_variant1=0
-opt_variant2=0
-opt_variant3=0
-opt_variant3a=0
-opt_variant4=0
-opt_variantl1tf=0
-opt_allvariants=1
+opt_cve_list=''
+opt_cve_all=1
 opt_no_sysfs=0
 opt_sysfs_only=0
 opt_coreos=0
 opt_arch_prefix=''
 opt_hw_only=0
 opt_no_hw=0
+opt_vmm=-1
 opt_explain=0
 opt_paranoid=0
+opt_mock=0
 
 global_critical=0
 global_unknown=0
-nrpe_vuln=""
+nrpe_vuln=''
+
+supported_cve_list='CVE-2017-5753 CVE-2017-5715 CVE-2017-5754 CVE-2018-3640 CVE-2018-3639 CVE-2018-3615 CVE-2018-3620 CVE-2018-3646 CVE-2018-12126 CVE-2018-12130 CVE-2018-12127 CVE-2019-11091'
 
 # find a sane command to print colored messages, we prefer `printf` over `echo`
 # because `printf` behavior is more standard across Linux/BSD
 # we'll try to avoid using shell builtins that might not take options
-echo_cmd_type=echo
-if which printf >/dev/null 2>&1; then
-	echo_cmd=$(which printf)
-	echo_cmd_type=printf
+echo_cmd_type='echo'
+# ignore SC2230 here because `which` ignores builtins while `command -v` doesn't, and
+# we don't want builtins here. Even if `which` is not installed, we'll fallback to the
+# `echo` builtin anyway, so this is safe.
+# shellcheck disable=SC2230
+if command -v printf >/dev/null 2>&1; then
+	echo_cmd=$(command -v printf)
+	echo_cmd_type='printf'
 elif which echo >/dev/null 2>&1; then
 	echo_cmd=$(which echo)
 else
@@ -163,7 +179,7 @@ else
 	[ -x /system/bin/echo ] && echo_cmd=/system/bin/echo
 fi
 # still empty? fallback to builtin
-[ -z "$echo_cmd" ] && echo_cmd=echo
+[ -z "$echo_cmd" ] && echo_cmd='echo'
 __echo()
 {
 	opt="$1"
@@ -248,29 +264,53 @@ explain()
 	fi
 }
 
+cve2name()
+{
+	case "$1" in
+		CVE-2017-5753)	echo "Spectre Variant 1, bounds check bypass";;
+		CVE-2017-5715)	echo "Spectre Variant 2, branch target injection";;
+		CVE-2017-5754)	echo "Variant 3, Meltdown, rogue data cache load";;
+		CVE-2018-3640)	echo "Variant 3a, rogue system register read";;
+		CVE-2018-3639)	echo "Variant 4, speculative store bypass";;
+		CVE-2018-3615)	echo "Foreshadow (SGX), L1 terminal fault";;
+		CVE-2018-3620)	echo "Foreshadow-NG (OS), L1 terminal fault";;
+		CVE-2018-3646)	echo "Foreshadow-NG (VMM), L1 terminal fault";;
+		CVE-2018-12126) echo "Fallout, microarchitectural store buffer data sampling (MSBDS)";;
+		CVE-2018-12130) echo "ZombieLoad, microarchitectural fill buffer data sampling (MFBDS)";;
+		CVE-2018-12127) echo "RIDL, microarchitectural load port data sampling (MLPDS)";;
+		CVE-2019-11091) echo "RIDL, microarchitectural data sampling uncacheable memory (MDSUM)";;
+		*) echo "$0: error: invalid CVE '$1' passed to cve2name()" >&2; exit 255;;
+	esac
+}
+
 is_cpu_vulnerable_cached=0
 _is_cpu_vulnerable_cached()
 {
 	# shellcheck disable=SC2086
-	{
-		[ "$1" = 1    ] && return $variant1
-		[ "$1" = 2    ] && return $variant2
-		[ "$1" = 3    ] && return $variant3
-		[ "$1" = 3a   ] && return $variant3a
-		[ "$1" = 4    ] && return $variant4
-		[ "$1" = l1tf ] && return $variantl1tf
-	}
-	echo "$0: error: invalid variant '$1' passed to is_cpu_vulnerable()" >&2
-	exit 255
+	case "$1" in
+		CVE-2017-5753) return $variant1;;
+		CVE-2017-5715) return $variant2;;
+		CVE-2017-5754) return $variant3;;
+		CVE-2018-3640) return $variant3a;;
+		CVE-2018-3639) return $variant4;;
+		CVE-2018-3615) return $variantl1tf_sgx;;
+		CVE-2018-3620) return $variantl1tf;;
+		CVE-2018-3646) return $variantl1tf;;
+		CVE-2018-12126) return $variant_msbds;;
+		CVE-2018-12130) return $variant_mfbds;;
+		CVE-2018-12127) return $variant_mlpds;;
+		CVE-2019-11091) return $variant_mdsum;;
+		*) echo "$0: error: invalid variant '$1' passed to is_cpu_vulnerable()" >&2; exit 255;;
+	esac
 }
 
 is_cpu_vulnerable()
 {
-	# param: 1, 2, 3, 3a or 4 (variant)
+	# param: one of the $supported_cve_list items
 	# returns 0 if vulnerable, 1 if not vulnerable
 	# (note that in shell, a return of 0 is success)
 	# by default, everything is vulnerable, we work in a "whitelist" logic here.
-	# usage: is_cpu_vulnerable 2 && do something if vulnerable
+	# usage: is_cpu_vulnerable CVE-xxxx-yyyy && do something if vulnerable
 	if [ "$is_cpu_vulnerable_cached" = 1 ]; then
 		_is_cpu_vulnerable_cached "$1"
 		return $?
@@ -282,6 +322,18 @@ is_cpu_vulnerable()
 	variant3a=''
 	variant4=''
 	variantl1tf=''
+	variant_msbds=''
+	variant_mfbds=''
+	variant_mlpds=''
+	variant_mdsum=''
+
+	if is_cpu_mds_free; then
+		[ -z "$variant_msbds" ] && variant_msbds=immune
+		[ -z "$variant_mfbds" ] && variant_mfbds=immune
+		[ -z "$variant_mlpds" ] && variant_mlpds=immune
+		[ -z "$variant_mdsum" ] && variant_mdsum=immune
+		_debug "is_cpu_vulnerable: cpu not affected by Microarchitectural Data Sampling"
+	fi
 
 	if is_cpu_specex_free; then
 		variant1=immune
@@ -290,6 +342,10 @@ is_cpu_vulnerable()
 		variant3a=immune
 		variant4=immune
 		variantl1tf=immune
+		variant_msbds=immune
+		variant_mfbds=immune
+		variant_mlpds=immune
+		variant_mdsum=immune
 	elif is_intel; then
 		# Intel
 		# https://github.com/crozone/SpectrePoC/issues/1 ^F E5200 => spectre 2 not vulnerable
@@ -328,29 +384,33 @@ is_cpu_vulnerable()
 		fi
 		# L1TF (RDCL_NO already checked above)
 		if [ "$cpu_family" = 6 ]; then
-			if [ "$cpu_model" = "$INTEL_FAM6_ATOM_CEDARVIEW"          ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_CLOVERVIEW" ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_LINCROFT" ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_PENWELL" ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_PINEVIEW" ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_SILVERMONT1" ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_SILVERMONT2" ] || \
+			if [ "$cpu_model" = "$INTEL_FAM6_ATOM_SALTWELL"          ] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_SALTWELL_TABLET" ] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_SALTWELL_MID" ] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_BONNELL" ] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_BONNELL_MID" ] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_SILVERMONT" ] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_SILVERMONT_MID" ] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_SILVERMONT_X" ] || \
 				[ "$cpu_model" = "$INTEL_FAM6_ATOM_AIRMONT" ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_MERRIFIELD" ] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_AIRMONT_MID" ] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_GOLDMONT" ] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_GOLDMONT_X" ] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_GOLDMONT_PLUS" ] || \
 				[ "$cpu_model" = "$INTEL_FAM6_XEON_PHI_KNL"     ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_XEON_PHI_KNM"     ]; then
+				[ "$cpu_model" = "$INTEL_FAM6_XEON_PHI_KNM" ]; then
 
 				_debug "is_cpu_vulnerable: intel family 6 but model known to be immune"
 				[ -z "$variantl1tf" ] && variantl1tf=immune
 			else
 				_debug "is_cpu_vulnerable: intel family 6 is vuln"
-				variantl1tf=vuln
+				[ -z "$variantl1tf" ] && variantl1tf=vuln
 			fi
 		elif [ "$cpu_family" -lt 6 ]; then
 			_debug "is_cpu_vulnerable: intel family < 6 is immune"
 			[ -z "$variantl1tf" ] && variantl1tf=immune
 		fi
-	elif is_amd; then
+	elif is_amd || is_hygon; then
 		# AMD revised their statement about variant2 => vulnerable
 		# https://www.amd.com/en/corporate/speculative-execution
 		variant1=vuln
@@ -437,7 +497,7 @@ is_cpu_vulnerable()
 					[ -z "$variant3a" ] && variant3a=immune
 					variant4=vuln
 					_debug "checking cpu$i: armv8 A76 non vulnerable to variant 2, 3 & 3a"
-				elif [ "$cpuarch" -le 7 ] || ( [ "$cpuarch" = 8 ] && [ $(( cpupart )) -lt $(( 0xd07 )) ] ) ; then
+				elif [ "$cpuarch" -le 7 ] || { [ "$cpuarch" = 8 ] && [ $(( cpupart )) -lt $(( 0xd07 )) ]; } ; then
 					[ -z "$variant1" ] && variant1=immune
 					[ -z "$variant2" ] && variant2=immune
 					[ -z "$variant3" ] && variant3=immune
@@ -458,13 +518,20 @@ is_cpu_vulnerable()
 		variantl1tf=immune
 	fi
 	_debug "is_cpu_vulnerable: temp results are <$variant1> <$variant2> <$variant3> <$variant3a> <$variant4> <$variantl1tf>"
-	[ "$variant1"    = "immune" ] && variant1=1    || variant1=0
-	[ "$variant2"    = "immune" ] && variant2=1    || variant2=0
-	[ "$variant3"    = "immune" ] && variant3=1    || variant3=0
-	[ "$variant3a"   = "immune" ] && variant3a=1   || variant3a=0
-	[ "$variant4"    = "immune" ] && variant4=1    || variant4=0
-	[ "$variantl1tf" = "immune" ] && variantl1tf=1 || variantl1tf=0
-	_debug "is_cpu_vulnerable: final results are <$variant1> <$variant2> <$variant3> <$variant3a> <$variant4> <$variantl1tf>"
+	[ "$variant1"      = "immune" ] && variant1=1      || variant1=0
+	[ "$variant2"      = "immune" ] && variant2=1      || variant2=0
+	[ "$variant3"      = "immune" ] && variant3=1      || variant3=0
+	[ "$variant3a"     = "immune" ] && variant3a=1     || variant3a=0
+	[ "$variant4"      = "immune" ] && variant4=1      || variant4=0
+	[ "$variantl1tf"   = "immune" ] && variantl1tf=1   || variantl1tf=0
+	[ "$variant_msbds" = "immune" ] && variant_msbds=1 || variant_msbds=0
+	[ "$variant_mfbds" = "immune" ] && variant_mfbds=1 || variant_mfbds=0
+	[ "$variant_mlpds" = "immune" ] && variant_mlpds=1 || variant_mlpds=0
+	[ "$variant_mdsum" = "immune" ] && variant_mdsum=1 || variant_mdsum=0
+	variantl1tf_sgx="$variantl1tf"
+	# even if we are vulnerable to L1TF, if there's no SGX, we're safe for the original foreshadow
+	[ "$cpuid_sgx" = 0 ] && variantl1tf_sgx=1
+	_debug "is_cpu_vulnerable: final results are <$variant1> <$variant2> <$variant3> <$variant3a> <$variant4> <$variantl1tf> <$variantl1tf_sgx>"
 	is_cpu_vulnerable_cached=1
 	_is_cpu_vulnerable_cached "$1"
 	return $?
@@ -475,23 +542,24 @@ is_cpu_specex_free()
 	# return true (0) if the CPU doesn't do speculative execution, false (1) if it does.
 	# if it's not in the list we know, return false (1).
 	# source: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/cpu/common.c#n882
-	# { X86_VENDOR_INTEL,     6, INTEL_FAM6_ATOM_CEDARVIEW,   X86_FEATURE_ANY },
-	# { X86_VENDOR_INTEL,     6, INTEL_FAM6_ATOM_CLOVERVIEW,  X86_FEATURE_ANY },
-	# { X86_VENDOR_INTEL,     6, INTEL_FAM6_ATOM_LINCROFT,    X86_FEATURE_ANY },
-	# { X86_VENDOR_INTEL,     6, INTEL_FAM6_ATOM_PENWELL,     X86_FEATURE_ANY },
-	# { X86_VENDOR_INTEL,     6, INTEL_FAM6_ATOM_PINEVIEW,    X86_FEATURE_ANY },
+	# { X86_VENDOR_INTEL,	6, INTEL_FAM6_ATOM_SALTWELL,	X86_FEATURE_ANY },
+	# { X86_VENDOR_INTEL,	6, INTEL_FAM6_ATOM_SALTWELL_TABLET,	X86_FEATURE_ANY },
+	# { X86_VENDOR_INTEL,	6, INTEL_FAM6_ATOM_BONNELL_MID,	X86_FEATURE_ANY },
+	# { X86_VENDOR_INTEL,	6, INTEL_FAM6_ATOM_SALTWELL_MID,	X86_FEATURE_ANY },
+	# { X86_VENDOR_INTEL,	6, INTEL_FAM6_ATOM_BONNELL,	X86_FEATURE_ANY },
 	# { X86_VENDOR_CENTAUR,   5 },
 	# { X86_VENDOR_INTEL,     5 },
 	# { X86_VENDOR_NSC,       5 },
 	# { X86_VENDOR_ANY,       4 },
+
 	parse_cpu_details
 	if is_intel; then
 		if [ "$cpu_family" = 6 ]; then
-			if [ "$cpu_model" = "$INTEL_FAM6_ATOM_CEDARVIEW"  ]      || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_CLOVERVIEW" ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_LINCROFT"   ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_PENWELL"    ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_PINEVIEW"   ]; then
+			if [ "$cpu_model" = "$INTEL_FAM6_ATOM_SALTWELL"	] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_SALTWELL_TABLET"	] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_BONNELL_MID"		] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_SALTWELL_MID"	] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_BONNELL"	]; then
 				return 0
 			fi
 		elif [ "$cpu_family" = 5 ]; then
@@ -502,6 +570,52 @@ is_cpu_specex_free()
 	return 1
 }
 
+is_cpu_mds_free()
+{
+	# return true (0) if the CPU isn't affected by microarchitectural data sampling, false (1) if it does.
+	# if it's not in the list we know, return false (1).
+	# source: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/cpu/common.c
+	#VULNWL_INTEL(ATOM_GOLDMONT,             NO_MDS | NO_L1TF),
+	#VULNWL_INTEL(ATOM_GOLDMONT_X,           NO_MDS | NO_L1TF),
+	#VULNWL_INTEL(ATOM_GOLDMONT_PLUS,        NO_MDS | NO_L1TF),
+
+	#/* AMD Family 0xf - 0x12 */
+	#VULNWL_AMD(0x0f,        NO_MELTDOWN | NO_SSB | NO_L1TF | NO_MDS),
+	#VULNWL_AMD(0x10,        NO_MELTDOWN | NO_SSB | NO_L1TF | NO_MDS),
+	#VULNWL_AMD(0x11,        NO_MELTDOWN | NO_SSB | NO_L1TF | NO_MDS),
+	#VULNWL_AMD(0x12,        NO_MELTDOWN | NO_SSB | NO_L1TF | NO_MDS),
+
+	#/* FAMILY_ANY must be last, otherwise 0x0f - 0x12 matches won't work */
+	#VULNWL_AMD(X86_FAMILY_ANY,      NO_MELTDOWN | NO_L1TF | NO_MDS),
+	#VULNWL_HYGON(X86_FAMILY_ANY,    NO_MELTDOWN | NO_L1TF | NO_MDS),
+	parse_cpu_details
+	if is_intel; then
+		if [ "$cpu_family" = 6 ]; then
+			if [ "$cpu_model" = "$INTEL_FAM6_ATOM_GOLDMONT" ] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_GOLDMONT_X" ] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_GOLDMONT_PLUS" ]; then
+				return 0
+			fi
+		fi
+		[ "$capabilities_mds_no" = 1 ] && return 0
+	fi
+
+	# official statement from AMD says none of their CPUs are vulnerable
+	# https://www.amd.com/en/corporate/product-security
+	# https://www.amd.com/system/files/documents/security-whitepaper.pdf
+	if is_amd; then
+		return 0
+	elif is_hygon; then
+		return 0
+	elif [ "$cpu_vendor" = CAVIUM ]; then
+		return 0
+	elif [ "$cpu_vendor" = ARM ]; then
+		return 0
+	fi
+
+	return 1
+}
+
 is_cpu_ssb_free()
 {
 	# return true (0) if the CPU isn't affected by speculative store bypass, false (1) if it does.
@@ -509,10 +623,10 @@ is_cpu_ssb_free()
 	# source1: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/cpu/common.c#n945
 	# source2: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git/tree/arch/x86/kernel/cpu/common.c
 	# Only list CPUs that speculate but are immune, to avoid duplication of cpus listed in is_cpu_specex_free()
-	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_ATOM_SILVERMONT1	},
+	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_ATOM_SILVERMONT	},
 	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_ATOM_AIRMONT		},
-	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_ATOM_SILVERMONT2	},
-	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_ATOM_MERRIFIELD	},
+	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_ATOM_SILVERMONT_X	},
+	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_ATOM_SILVERMONT_MID	},
 	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_CORE_YONAH		},
 	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_XEON_PHI_KNL		},
 	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_XEON_PHI_KNM		},
@@ -524,9 +638,9 @@ is_cpu_ssb_free()
 	if is_intel; then
 		if [ "$cpu_family" = 6 ]; then
 			if [ "$cpu_model" = "$INTEL_FAM6_ATOM_AIRMONT"          ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_SILVERMONT1" ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_SILVERMONT2" ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_MERRIFIELD"  ]; then
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_SILVERMONT" ] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_SILVERMONT_X" ] || \
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_SILVERMONT_MID"  ]; then
 				return 0
 			elif [ "$cpu_model" = "$INTEL_FAM6_CORE_YONAH"          ] || \
 				[ "$cpu_model" = "$INTEL_FAM6_XEON_PHI_KNL"     ] || \
@@ -542,7 +656,10 @@ is_cpu_ssb_free()
 			[ "$cpu_family" = "15" ]; then 
 			return 0
 		fi
-	fi			
+	fi
+	if is_hygon; then
+		return 1
+	fi
 	[ "$cpu_family" = 4 ] && return 0
 	return 1
 }
@@ -551,6 +668,70 @@ show_header()
 {
 	_info "Spectre and Meltdown mitigation detection tool v$VERSION"
 	_info
+}
+
+[ -z "$HOME" ] && HOME="$(getent passwd "$(whoami)" | cut -d: -f6)"
+mcedb_cache="$HOME/.mcedb"
+update_mcedb()
+{
+	# We're using MCE.db from the excellent platomav's MCExtractor project
+	show_header
+
+	if [ -r "$mcedb_cache" ]; then
+		previous_mcedb_revision=$(awk '/^# %%% MCEDB / { print $4 }' "$mcedb_cache")
+	fi
+
+	# first download the database
+	mcedb_tmp="$(mktemp /tmp/mcedb-XXXXXX)"
+	mcedb_url='https://github.com/platomav/MCExtractor/raw/master/MCE.db'
+	_info_nol "Fetching MCE.db from the MCExtractor project... "
+	if command -v wget >/dev/null 2>&1; then
+		wget -q "$mcedb_url" -O "$mcedb_tmp"; ret=$?
+	elif command -v curl >/dev/null 2>&1; then
+		curl -sL "$mcedb_url" -o "$mcedb_tmp"; ret=$?
+	elif command -v fetch >/dev/null 2>&1; then
+		fetch -q "$mcedb_url" -o "$mcedb_tmp"; ret=$?
+	else
+		echo ERROR "please install one of \`wget\`, \`curl\` of \`fetch\` programs"
+		return 1
+	fi
+	if [ "$ret" != 0 ]; then
+		echo ERROR "error $ret while downloading MCE.db"
+		return $ret
+	fi
+	echo DONE
+
+	# now extract contents using sqlite
+	_info_nol "Extracting data... "
+	if ! command -v sqlite3 >/dev/null 2>&1; then
+		echo ERROR "please install the \`sqlite3\` program"
+		return 1
+	fi
+	mcedb_revision=$(sqlite3 "$mcedb_tmp" "select revision from MCE")
+	mcedb_date=$(sqlite3 "$mcedb_tmp" "select strftime('%Y/%m/%d', date, 'unixepoch') from MCE")
+	if [ -z "$mcedb_revision" ]; then
+		echo ERROR "downloaded file seems invalid"
+		return 1
+	fi
+	echo OK "MCExtractor database revision $mcedb_revision dated $mcedb_date"
+	if [ -n "$previous_mcedb_revision" ]; then
+		if [ "$previous_mcedb_revision" = "v$mcedb_revision" ]; then
+			echo "We already have this version locally, no update needed"
+			[ "$1" != builtin ] && return 0
+		fi
+	fi
+	echo "# Spectre & Meltdown Checker" > "$mcedb_cache"
+	echo "# %%% MCEDB v$mcedb_revision - $mcedb_date" >> "$mcedb_cache"
+	sqlite3 "$mcedb_tmp" "select '# I,0x'||cpuid||',0x'||version||','||max(yyyymmdd) from Intel group by cpuid order by cpuid asc; select '# A,0x'||cpuid||',0x'||version||','||max(yyyymmdd) from AMD group by cpuid order by cpuid asc" | grep -v '^# .,0x00000000,' >> "$mcedb_cache"
+	echo OK "local version updated"
+
+	if [ "$1" = builtin ]; then
+		newfile=$(mktemp /tmp/smc-XXXXXX)
+		awk '/^# %%% MCEDB / { exit }; { print }' "$0" > "$newfile"
+		awk '{ if (NR>1) { print } }' "$mcedb_cache" >> "$newfile"
+		cat "$newfile" > "$0"
+		rm -f "$newfile"
+	fi
 }
 
 parse_opt_file()
@@ -631,15 +812,25 @@ while [ -n "$1" ]; do
 		# deprecated, kept for compatibility
 		opt_explain=0
 		shift
+	elif [ "$1" = "--update-mcedb" ]; then
+		update_mcedb
+		exit $?
+	elif [ "$1" = "--update-builtin-mcedb" ]; then
+		update_mcedb builtin
+		exit $?
+	elif [ "$1" = "--dump-mock-data" ]; then
+		opt_mock=1
+		shift
 	elif [ "$1" = "--explain" ]; then
 		opt_explain=1
 		shift
 	elif [ "$1" = "--batch" ]; then
 		opt_batch=1
 		opt_verbose=0
+		opt_no_color=1
 		shift
 		case "$1" in
-			text|nrpe|json|prometheus) opt_batch_format="$1"; shift;;
+			text|short|nrpe|json|prometheus) opt_batch_format="$1"; shift;;
 			--*) ;;    # allow subsequent flags
 			'') ;;     # allow nothing at all
 			*)
@@ -650,21 +841,52 @@ while [ -n "$1" ]; do
 		esac
 	elif [ "$1" = "-v" ] || [ "$1" = "--verbose" ]; then
 		opt_verbose=$(( opt_verbose + 1 ))
+		[ "$opt_verbose" -ge 2 ] && opt_mock=1
 		shift
+	elif [ "$1" = "--cve" ]; then
+		if [ -z "$2" ]; then
+			echo "$0: error: option --cve expects a parameter, supported CVEs are: $supported_cve_list" >&2
+			exit 255
+		fi
+		selected_cve=$(echo "$supported_cve_list" | grep -iwo "$2")
+		if [ -n "$selected_cve" ]; then
+			opt_cve_list="$opt_cve_list $selected_cve"
+			opt_cve_all=0
+		else
+			echo "$0: error: unsupported CVE specified ('$2'), supported CVEs are: $supported_cve_list" >&2
+			exit 255
+		fi
+		shift 2
+	elif [ "$1" = "--vmm" ]; then
+		if [ -z "$2" ]; then
+			echo "$0: error: option --vmm (auto, yes, no)" >&2
+			exit 255
+		fi
+		case "$2" in
+			auto) opt_vmm=-1;;
+			yes)  opt_vmm=1;;
+			no)   opt_vmm=0;;
+			*)    echo "$0: error: expected one of (auto, yes, no) to option --vmm instead of '$2'" >&2; exit 255;;
+		esac
+		shift 2
 	elif [ "$1" = "--variant" ]; then
 		if [ -z "$2" ]; then
 			echo "$0: error: option --variant expects a parameter (1, 2, 3, 3a, 4 or l1tf)" >&2
 			exit 255
 		fi
 		case "$2" in
-			1)    opt_variant1=1;    opt_allvariants=0;;
-			2)    opt_variant2=1;    opt_allvariants=0;;
-			3)    opt_variant3=1;    opt_allvariants=0;;
-			3a)   opt_variant3a=1;   opt_allvariants=0;;
-			4)    opt_variant4=1;    opt_allvariants=0;;
-			l1tf) opt_variantl1tf=1; opt_allvariants=0;;
+			1)		opt_cve_list="$opt_cve_list CVE-2017-5753"; opt_cve_all=0;;
+			2)		opt_cve_list="$opt_cve_list CVE-2017-5715"; opt_cve_all=0;;
+			3)		opt_cve_list="$opt_cve_list CVE-2017-5754"; opt_cve_all=0;;
+			3a)		opt_cve_list="$opt_cve_list CVE-2018-3640"; opt_cve_all=0;;
+			4)		opt_cve_list="$opt_cve_list CVE-2018-3639"; opt_cve_all=0;;
+			msbds)  opt_cve_list="$opt_cve_list CVE-2018-12126"; opt_cve_all=0;;
+			mfbds)  opt_cve_list="$opt_cve_list CVE-2018-12130"; opt_cve_all=0;;
+			mlpds)  opt_cve_list="$opt_cve_list CVE-2018-12127"; opt_cve_all=0;;
+			mdsum)  opt_cve_list="$opt_cve_list CVE-2019-11091"; opt_cve_all=0;;
+			l1tf)	opt_cve_list="$opt_cve_list CVE-2018-3615 CVE-2018-3620 CVE-2018-3646"; opt_cve_all=0;;
 			*)
-				echo "$0: error: invalid parameter '$2' for --variant, expected either 1, 2, 3, 3a, 4 or l1tf" >&2;
+				echo "$0: error: invalid parameter '$2' for --variant, expected either 1, 2, 3, 3a, 4, msbds, mfbds, mlpds, mdsum, or l1tf" >&2;
 				exit 255
 				;;
 		esac
@@ -733,16 +955,25 @@ pvulnstatus()
 			CVE-2017-5754) aka="MELTDOWN";;
 			CVE-2018-3640) aka="VARIANT 3A";;
 			CVE-2018-3639) aka="VARIANT 4";;
-			CVE-2018-3615/3620/3646) aka="L1TF";;
+			CVE-2018-3615) aka="L1TF SGX";;
+			CVE-2018-3620) aka="L1TF OS";;
+			CVE-2018-3646) aka="L1TF VMM";;
+			CVE-2018-12126) aka="MSBDS";;
+			CVE-2018-12130) aka="MFBDS";;
+			CVE-2018-12127) aka="MLPDS";;
+			CVE-2019-11091) aka="MDSUM";;
+			*) echo "$0: error: invalid CVE '$1' passed to pvulnstatus()" >&2; exit 255;;
 		esac
 
 		case "$opt_batch_format" in
 			text) _echo 0 "$1: $2 ($3)";;
+			short) short_output="${short_output}$1 ";;
 			json)
 				case "$2" in
 					UNK)  is_vuln="null";;
 					VULN) is_vuln="true";;
 					OK)   is_vuln="false";;
+					*)    echo "$0: error: unknown status '$2' passed to pvulnstatus()" >&2; exit 255;;
 				esac
 				json_output="${json_output:-[}{\"NAME\":\"$aka\",\"CVE\":\"$1\",\"VULNERABLE\":$is_vuln,\"INFOS\":\"$3\"},"
 				;;
@@ -751,6 +982,7 @@ pvulnstatus()
 			prometheus)
 				prometheus_output="${prometheus_output:+$prometheus_output\n}specex_vuln_status{name=\"$aka\",cve=\"$1\",status=\"$2\",info=\"$3\"} 1"
 				;;
+			*) echo "$0: error: invalid batch format '$opt_batch_format' specified" >&2; exit 255;;
 		esac
 	fi
 
@@ -758,6 +990,8 @@ pvulnstatus()
 	case "$2" in
 		UNK)  global_unknown="1";;
 		VULN) global_critical="1";;
+		OK)   ;;
+		*)    echo "$0: error: unknown status '$2' passed to pvulnstatus()" >&2; exit 255;;
 	esac
 
 	# display info if we're not in quiet/batch mode
@@ -765,9 +999,10 @@ pvulnstatus()
 	shift 2
 	_info_nol "> \033[46m\033[30mSTATUS:\033[0m "
 	case "$vulnstatus" in
-		UNK)  pstatus yellow 'UNKNOWN'        "$@";;
-		VULN) pstatus red    'VULNERABLE'     "$@";;
-		OK)   pstatus green  'NOT VULNERABLE' "$@";;
+		UNK)  pstatus yellow 'UNKNOWN'        "$@"; final_summary="$final_summary \033[43m\033[30m$pvulnstatus_last_cve:??\033[0m";;
+		VULN) pstatus red    'VULNERABLE'     "$@"; final_summary="$final_summary \033[41m\033[30m$pvulnstatus_last_cve:KO\033[0m";;
+		OK)   pstatus green  'NOT VULNERABLE' "$@"; final_summary="$final_summary \033[42m\033[30m$pvulnstatus_last_cve:OK\033[0m";;
+		*)    echo "$0: error: unknown status '$vulnstatus' passed to pvulnstatus()" >&2; exit 255;;
 	esac
 }
 
@@ -832,7 +1067,7 @@ try_decompress()
 	for     pos in $(tr "$1\n$2" "\n$2=" < "$6" | grep -abo "^$2")
 	do
 		_debug "try_decompress: magic for $3 found at offset $pos"
-		if ! which "$3" >/dev/null 2>&1; then
+		if ! command -v "$3" >/dev/null 2>&1; then
 			kernel_err="missing '$3' tool, please install it, usually it's in the '$5' package"
 			return 0
 		fi
@@ -899,7 +1134,7 @@ mount_debugfs()
 load_msr()
 {
 	if [ "$os" = Linux ]; then
-		if ! grep -e msr /proc/modules 2>/dev/null; then
+		if ! grep -e msr "$procfs/modules" 2>/dev/null; then
 			modprobe msr 2>/dev/null && insmod_msr=1
 			_debug "attempted to load module msr, insmod_msr=$insmod_msr"
 		else
@@ -918,7 +1153,7 @@ load_msr()
 load_cpuid()
 {
 	if [ "$os" = Linux ]; then
-		if ! grep -e cpuid /proc/modules 2>/dev/null; then
+		if ! grep -e cpuid "$procfs/modules" 2>/dev/null; then
 			modprobe cpuid 2>/dev/null && insmod_cpuid=1
 			_debug "attempted to load module cpuid, insmod_cpuid=$insmod_cpuid"
 		else
@@ -958,14 +1193,23 @@ read_cpuid()
 
 	if [ -e /dev/cpu/0/cpuid ]; then
 		# Linux
+		if [ ! -r /dev/cpu/0/cpuid ]; then
+			return 2
+		fi
+		# on some kernel versions, /dev/cpu/0/cpuid doesn't imply that the cpuid module is loaded, in that case dd returns an error
+		dd if=/dev/cpu/0/cpuid bs=16 count=1 >/dev/null 2>&1 || load_cpuid
 		# we need _leaf to be converted to decimal for dd
 		_leaf=$(( _leaf ))
 		# to avoid using iflag=skip_bytes, which doesn't exist on old versions of dd, seek to the closer multiple-of-16
 		_ddskip=$(( _leaf / 16 ))
 		_odskip=$(( _leaf - _ddskip * 16 ))
+		# now read the value
 		_cpuid=$(dd if=/dev/cpu/0/cpuid bs=16 skip=$_ddskip count=$((_odskip + 1)) 2>/dev/null | od -j $((_odskip * 16)) -A n -t u4)
 	elif [ -e /dev/cpuctl0 ]; then
 		# BSD
+		if [ ! -r /dev/cpuctl0 ]; then
+			return 2
+		fi
 		_cpuid=$(cpucontrol -i "$_leaf" /dev/cpuctl0 2>/dev/null | awk '{print $4,$5,$6,$7}')
 		# cpuid level 0x1: 0x000306d4 0x00100800 0x4dfaebbf 0xbfebfbff
 	else
@@ -973,6 +1217,14 @@ read_cpuid()
 	fi
 
 	_debug "cpuid: leaf$_leaf on cpu0, eax-ebx-ecx-edx: $_cpuid"
+	_mockvarname="SMC_MOCK_CPUID_${_leaf}"
+	if [ -n "$(eval echo \$$_mockvarname)" ]; then
+		_cpuid="$(eval echo \$$_mockvarname)"
+		_debug "read_cpuid: MOCKING enabled for leaf $_leaf, will return $_cpuid"
+		mocked=1
+	else
+		mockme=$(printf "%b\n%b" "$mockme" "SMC_MOCK_CPUID_${_leaf}='$_cpuid'")
+	fi
 	[ -z "$_cpuid" ] && return 2
 	# get the value of the register we want
 	_reg=$(echo "$_cpuid" | awk '{print $'"$_register"'}')
@@ -1016,7 +1268,7 @@ dmesg_grep()
 
 is_coreos()
 {
-	which coreos-install >/dev/null 2>&1 && which toolbox >/dev/null 2>&1 && return 0
+	command -v coreos-install >/dev/null 2>&1 && command -v toolbox >/dev/null 2>&1 && return 0
 	return 1
 }
 
@@ -1056,9 +1308,47 @@ parse_cpu_details()
 		cpu_friendly_name=$(sysctl -n hw.model)
 	fi
 
+	if [ -n "$SMC_MOCK_CPU_FRIENDLY_NAME" ]; then
+		cpu_friendly_name="$SMC_MOCK_CPU_FRIENDLY_NAME"
+		_debug "parse_cpu_details: MOCKING cpu friendly name to $cpu_friendly_name"
+		mocked=1
+	else
+		mockme=$(printf "%b\n%b" "$mockme" "SMC_MOCK_CPU_FRIENDLY_NAME='$cpu_friendly_name'")
+	fi
+	if [ -n "$SMC_MOCK_CPU_VENDOR" ]; then
+		cpu_vendor="$SMC_MOCK_CPU_VENDOR"
+		_debug "parse_cpu_details: MOCKING cpu vendor to $cpu_vendor"
+		mocked=1
+	else
+		mockme=$(printf "%b\n%b" "$mockme" "SMC_MOCK_CPU_VENDOR='$cpu_vendor'")
+	fi
+	if [ -n "$SMC_MOCK_CPU_FAMILY" ]; then
+		cpu_family="$SMC_MOCK_CPU_FAMILY"
+		_debug "parse_cpu_details: MOCKING cpu family to $cpu_family"
+		mocked=1
+	else
+		mockme=$(printf "%b\n%b" "$mockme" "SMC_MOCK_CPU_FAMILY='$cpu_family'")
+	fi
+	if [ -n "$SMC_MOCK_CPU_MODEL" ]; then
+		cpu_model="$SMC_MOCK_CPU_MODEL"
+		_debug "parse_cpu_details: MOCKING cpu model to $cpu_model"
+		mocked=1
+	else
+		mockme=$(printf "%b\n%b" "$mockme" "SMC_MOCK_CPU_MODEL='$cpu_model'")
+	fi
+	if [ -n "$SMC_MOCK_CPU_STEPPING" ]; then
+		cpu_stepping="$SMC_MOCK_CPU_STEPPING"
+		_debug "parse_cpu_details: MOCKING cpu stepping to $cpu_stepping"
+		mocked=1
+	else
+		mockme=$(printf "%b\n%b" "$mockme" "SMC_MOCK_CPU_STEPPING='$cpu_stepping'")
+	fi
+
 	# get raw cpuid, it's always useful (referenced in the Intel doc for firmware updates for example)
 	if read_cpuid 0x1 $EAX 0 0xFFFFFFFF; then
 		cpu_cpuid="$read_cpuid_value"
+	else
+		cpu_cpuid=0
 	fi
 
 	# under BSD, linprocfs often doesn't export ucode information, so fetch it ourselves the good old way
@@ -1076,6 +1366,17 @@ parse_cpu_details()
 			# convert back to hex
 			cpu_ucode=$(printf "0x%x" "$cpu_ucode")
 		fi
+	fi
+
+	# if we got no cpu_ucode (e.g. we're in a vm), fall back to 0x0
+	[ -z "$cpu_ucode" ] && cpu_ucode=0x0
+
+	if [ -n "$SMC_MOCK_CPU_UCODE" ]; then
+		cpu_ucode="$SMC_MOCK_CPU_UCODE"
+		_debug "parse_cpu_details: MOCKING cpu ucode to $cpu_ucode"
+		mocked=1
+	else
+		mockme=$(printf "%b\n%b" "$mockme" "SMC_MOCK_CPU_UCODE='$cpu_ucode'")
 	fi
 
 	echo "$cpu_ucode" | grep -q ^0x && cpu_ucode=$(( cpu_ucode ))
@@ -1124,19 +1425,19 @@ parse_cpu_details()
 
 	# /* "Small Core" Processors (Atom) */
 
-	INTEL_FAM6_ATOM_PINEVIEW=$(( 0x1C ))
-	INTEL_FAM6_ATOM_LINCROFT=$(( 0x26 ))
-	INTEL_FAM6_ATOM_PENWELL=$(( 0x27 ))
-	INTEL_FAM6_ATOM_CLOVERVIEW=$(( 0x35 ))
-	INTEL_FAM6_ATOM_CEDARVIEW=$(( 0x36 ))
-	INTEL_FAM6_ATOM_SILVERMONT1=$(( 0x37 ))
-	INTEL_FAM6_ATOM_SILVERMONT2=$(( 0x4D ))
+	INTEL_FAM6_ATOM_BONNELL=$(( 0x1C ))
+	INTEL_FAM6_ATOM_BONNELL_MID=$(( 0x26 ))
+	INTEL_FAM6_ATOM_SALTWELL_MID=$(( 0x27 ))
+	INTEL_FAM6_ATOM_SALTWELL_TABLET=$(( 0x35 ))
+	INTEL_FAM6_ATOM_SALTWELL=$(( 0x36 ))
+	INTEL_FAM6_ATOM_SILVERMONT=$(( 0x37 ))
+	INTEL_FAM6_ATOM_SILVERMONT_MID=$(( 0x4A ))
+	INTEL_FAM6_ATOM_SILVERMONT_X=$(( 0x4D ))
 	INTEL_FAM6_ATOM_AIRMONT=$(( 0x4C ))
-	INTEL_FAM6_ATOM_MERRIFIELD=$(( 0x4A ))
-	INTEL_FAM6_ATOM_MOOREFIELD=$(( 0x5A ))
+	INTEL_FAM6_ATOM_AIRMONT_MID=$(( 0x5A ))
 	INTEL_FAM6_ATOM_GOLDMONT=$(( 0x5C ))
-	INTEL_FAM6_ATOM_DENVERTON=$(( 0x5F ))
-	INTEL_FAM6_ATOM_GEMINI_LAKE=$(( 0x7A ))
+	INTEL_FAM6_ATOM_GOLDMONT_X=$(( 0x5F ))
+	INTEL_FAM6_ATOM_GOLDMONT_PLUS=$(( 0x7A ))
 
 	# /* Xeon Phi */
 
@@ -1144,6 +1445,11 @@ parse_cpu_details()
 	INTEL_FAM6_XEON_PHI_KNM=$(( 0x85 ))
 	}
 	parse_cpu_details_done=1
+}
+is_hygon()
+{
+	[ "$cpu_vendor" = HygonGenuine ] && return 0
+	return 1
 }
 
 is_amd()
@@ -1214,10 +1520,9 @@ is_ucode_blacklisted()
 	do
 		model=$(echo $tuple | cut -d, -f1)
 		stepping=$(( $(echo $tuple | cut -d, -f2) ))
-		ucode=$(echo $tuple | cut -d, -f3)
-		echo "$ucode" | grep -q ^0x && ucode_decimal=$(( ucode ))
 		if [ "$cpu_model" = "$model" ] && [ "$cpu_stepping" = "$stepping" ]; then
-			if [ "$cpu_ucode" = "$ucode_decimal" ] || [ "$cpu_ucode" = "$ucode" ]; then
+			ucode=$(( $(echo $tuple | cut -d, -f3) ))
+			if [ "$cpu_ucode" = "$ucode" ]; then
 				_debug "is_ucode_blacklisted: we have a match! ($cpu_model/$cpu_stepping/$cpu_ucode)"
 				return 0
 			fi
@@ -1232,7 +1537,7 @@ is_skylake_cpu()
 	# is this a skylake cpu?
 	# return 0 if yes, 1 otherwise
 	#if (boot_cpu_data.x86_vendor == X86_VENDOR_INTEL &&
-	#	    boot_cpu_data.x86 == 6) {
+	#		boot_cpu_data.x86 == 6) {
 	#		switch (boot_cpu_data.x86_model) {
 	#		case INTEL_FAM6_SKYLAKE_MOBILE:
 	#		case INTEL_FAM6_SKYLAKE_DESKTOP:
@@ -1272,64 +1577,102 @@ is_zen_cpu()
 	[ "$cpu_family" = 23 ] && return 0
 	return 1
 }
+is_moksha_cpu()
+{
+	parse_cpu_details
+	is_hygon || return 1
+	[ "$cpu_family" = 24 ] && return 0
+	return 1
+}
+
+# Test if the current host is a Xen PV Dom0 / DomU
+is_xen() {
+	if [ ! -d "$procfs/xen" ]; then
+		return 1
+	fi
+
+	# XXX do we have a better way that relying on dmesg?
+	dmesg_grep 'Booting paravirtualized kernel on Xen$'; ret=$?
+	if [ $ret -eq 2 ]; then
+		_warn "dmesg truncated, Xen detection will be unreliable. Please reboot and relaunch this script"
+		return 1
+	elif [ $ret -eq 0 ]; then
+		return 0
+	else
+		return 1
+	fi
+}
+
+is_xen_dom0()
+{
+	if ! is_xen; then
+		return 1
+	fi
+
+	if [ -e "$procfs/xen/capabilities" ] && grep -q "control_d" "$procfs/xen/capabilities"; then
+		return 0
+	else
+		return 1
+	fi
+}
+
+is_xen_domU()
+{
+	if ! is_xen; then
+		return 1
+	fi
+
+	# PVHVM guests also print 'Booting paravirtualized kernel', so we need this check.
+	dmesg_grep 'Xen HVM callback vector for event delivery is enabled$'; ret=$?
+	if [ $ret -eq 0 ]; then
+		return 1
+	fi
+
+	if ! is_xen_dom0; then
+		return 0
+	else
+		return 1
+	fi
+}
+
+if [ -r "$mcedb_cache" ]; then
+	mcedb_source="$mcedb_cache"
+	mcedb_info="local MCExtractor DB "$(grep -E '^# %%% MCEDB ' "$mcedb_source" | cut -c13-)
+else
+	mcedb_source="$0"
+	mcedb_info="builtin MCExtractor DB "$(grep -E '^# %%% MCEDB ' "$mcedb_source" | cut -c13-)
+fi
+read_mcedb()
+{
+	awk '{ if (DELIM==1) { print $2 } } /^# %%% MCEDB / { DELIM=1 }' "$mcedb_source"
+}
 
 is_latest_known_ucode()
 {
 	# 0: yes, 1: no, 2: unknown
 	parse_cpu_details
-	ucode_latest="latest microcode version of your CPU is not known to this script"
-	is_intel || return 2
-	# https://www.intel.com/content/dam/www/public/us/en/documents/sa00115-microcode-update-guidance.pdf
-	# ps2txt sa00115-microcode-update-guidance.ps | grep -Eo '[0-9A-F]+ [0-9A-F]+ [^ ]+ Production 0x[A-F0-9]+ 0x[^ ]+' | awk '{print "0x"$1","$6" \\"}' | uniq
-	# cpuid,ucode
-	for tuple in \
-		0x106A5,0x1D \
-		0x106E5,0x0A \
-		0x20652,0x11 \
-		0x20655,0x7 \
-		0x206A7,0x2E \
-		0x206C2,0x1F \
-		0x206D6,0x61D \
-		0x206D7,0x714 \
-		0x206E6,0x0D \
-		0x206F2,0x3B \
-		0x306A9,0x20 \
-		0x306C3,0x25 \
-		0x306D4,0x2B \
-		0x306E4,0x42D \
-		0x306E7,0x714 \
-		0x306F2,0x3D \
-		0x306F4,0x12 \
-		0x40651,0x24 \
-		0x40661,0x1A \
-		0x40671,0x1E \
-		0x406E3,0xC6 \
-		0x406F1,0xB00002E \
-		0x50654,0x200004D \
-		0x50662,0x17 \
-		0x50663,0x7000013 \
-		0x50664,0xF000012 \
-		0x50665,0xE00000A \
-		0x506C2,0x14 \
-		0x506E3,0xC6 \
-		0x506F1,0x24 \
-		0x706A1,0x28 \
-		0x806E9,0x8E \
-		0x806EA,0x96 \
-		0x906E9,0x8E \
-		0x906EA,0x96 \
-		0x906EB,0x8E
+	if [ "$cpu_cpuid" = 0 ]; then
+		ucode_latest="couldn't get your cpuid"
+		return 2
+	fi
+	ucode_latest="latest microcode version for your CPU model is unknown"
+	if is_intel; then
+		cpu_brand_prefix=I
+	elif is_amd; then
+		cpu_brand_prefix=A
+	else
+		return 2
+	fi
+	for tuple in $(read_mcedb | grep "$(printf "^$cpu_brand_prefix,0x%08X," "$cpu_cpuid")")
 	do
-		cpuid_decimal=$(( $(echo "$tuple" | cut -d, -f1) ))
-		ucode_decimal=$(( $(echo "$tuple" | cut -d, -f2) ))
-		ucode_latest=$(printf "you have version 0x%x and latest known version is 0x%x" "$cpu_ucode" "$ucode_decimal")
-		if [ "$cpuid_decimal" = "$cpu_cpuid" ]; then
-			_debug "is_latest_known_ucode: with cpuid $cpu_cpuid has ucode $cpu_ucode, last known is $cpuid_decimal"
-			if [ "$cpu_ucode" -ge "$ucode_decimal" ]; then
-				return 0
-			else
-				return 1
-			fi
+		ucode=$((  $(echo "$tuple" | cut -d, -f3) ))
+		ucode_date=$(echo "$tuple" | cut -d, -f4 | sed -r 's=(....)(..)(..)=\1/\2/\3=')
+		_debug "is_latest_known_ucode: with cpuid $cpu_cpuid has ucode $cpu_ucode, last known is $ucode from $ucode_date"
+		ucode_latest=$(printf "latest version is 0x%x dated $ucode_date according to $mcedb_info" "$ucode")
+		if [ "$cpu_ucode" -ge "$ucode" ]; then
+			return 0
+		else
+			return 1
 		fi
 	done
 	_debug "is_latest_known_ucode: this cpuid is not referenced ($cpu_cpuid)"
@@ -1355,17 +1698,13 @@ if [ "$opt_live_explicit" = 1 ]; then
 	fi
 fi
 if [ "$opt_hw_only" = 1 ]; then
-	if [ "$opt_allvariants" = 0 ]; then
+	if [ "$opt_cve_all" = 0 ]; then
 		show_usage
 		echo "$0: error: incompatible modes specified, --hw-only vs --variant" >&2
 		exit 255
 	else
-		opt_allvariants=0
-		opt_variant1=0
-		opt_variant2=0
-		opt_variant3=0
-		opt_variant3a=0
-		opt_variant4=0
+		opt_cve_all=0
+		opt_cve_list=''
 	fi
 fi
 
@@ -1425,9 +1764,9 @@ if [ "$opt_live" = 1 ]; then
 
 	# try to find the image of the current running kernel
 	# first, look for the BOOT_IMAGE hint in the kernel cmdline
-	if [ -r /proc/cmdline ] && grep -q 'BOOT_IMAGE=' /proc/cmdline; then
-		opt_kernel=$(grep -Eo 'BOOT_IMAGE=[^ ]+' /proc/cmdline | cut -d= -f2)
-		_debug "found opt_kernel=$opt_kernel in /proc/cmdline"
+	if [ -r "$procfs/cmdline" ] && grep -q 'BOOT_IMAGE=' "$procfs/cmdline"; then
+		opt_kernel=$(grep -Eo 'BOOT_IMAGE=[^ ]+' "$procfs/cmdline" | cut -d= -f2)
+		_debug "found opt_kernel=$opt_kernel in $procfs/cmdline"
 		# if the boot partition is within a btrfs subvolume, strip the subvolume name
 		# if /boot is a separate subvolume, the remainder of the code in this section should handle it
 		if echo "$opt_kernel" | grep -q "^/@"; then opt_kernel=$(echo "$opt_kernel" | sed "s:/@[^/]*::"); fi
@@ -1445,12 +1784,12 @@ if [ "$opt_live" = 1 ]; then
 		[ -e "/lib/modules/$(uname -r)/vmlinuz" ] && opt_kernel="/lib/modules/$(uname -r)/vmlinuz"
 		# Slackare:
 		[ -e "/boot/vmlinuz"             ] && opt_kernel="/boot/vmlinuz"
-		# Arch:
-		[ -e "/boot/vmlinuz-linux"       ] && opt_kernel="/boot/vmlinuz-linux"
 		# Arch aarch64:
 		[ -e "/boot/Image"               ] && opt_kernel="/boot/Image"
 		# Arch armv5/armv7:
 		[ -e "/boot/zImage"              ] && opt_kernel="/boot/zImage"
+		# Arch arm7:
+		[ -e "/boot/kernel7.img"         ] && opt_kernel="/boot/kernel7.img"
 		# Linux-Libre:
 		[ -e "/boot/vmlinuz-linux-libre" ] && opt_kernel="/boot/vmlinuz-linux-libre"
 		# pine64
@@ -1465,27 +1804,37 @@ if [ "$opt_live" = 1 ]; then
 		[ -e "/run/booted-system/kernel" ] && opt_kernel="/run/booted-system/kernel"
 		# systemd kernel-install:
 		[ -e "/etc/machine-id" ] && [ -e "/boot/$(cat /etc/machine-id)/$(uname -r)/linux" ] && opt_kernel="/boot/$(cat /etc/machine-id)/$(uname -r)/linux"
+		# Clear Linux:
+		str_uname=$(uname -r)
+		clear_linux_kernel="/lib/kernel/org.clearlinux.${str_uname##*.}.${str_uname%.*}"
+		[ -e "$clear_linux_kernel" ] && opt_kernel=$clear_linux_kernel
 	fi
 
 	# system.map
-	if [ -e /proc/kallsyms ] ; then
-		opt_map=/proc/kallsyms
+	if [ -e "$procfs/kallsyms" ] ; then
+		opt_map="$procfs/kallsyms"
 	elif [ -e "/lib/modules/$(uname -r)/System.map" ] ; then
 		opt_map="/lib/modules/$(uname -r)/System.map"
 	elif [ -e "/boot/System.map-$(uname -r)" ] ; then
 		opt_map="/boot/System.map-$(uname -r)"
+	elif [ -e "/lib/kernel/System.map-$(uname -r)" ]; then
+		opt_map="/lib/kernel/System.map-$(uname -r)"
 	fi
 
 	# config
-	if [ -e /proc/config.gz ] ; then
+	if [ -e "$procfs/config.gz" ] ; then
 		dumped_config="$(mktemp /tmp/config-XXXXXX)"
-		gunzip -c /proc/config.gz > "$dumped_config"
+		gunzip -c "$procfs/config.gz" > "$dumped_config"
 		# dumped_config will be deleted at the end of the script
 		opt_config="$dumped_config"
 	elif [ -e "/lib/modules/$(uname -r)/config" ]; then
 		opt_config="/lib/modules/$(uname -r)/config"
 	elif [ -e "/boot/config-$(uname -r)" ]; then
 		opt_config="/boot/config-$(uname -r)"
+	elif [ -e "/etc/kernels/kernel-config-$(uname -m)-$(uname -r)" ]; then
+		opt_config="/etc/kernels/kernel-config-$(uname -m)-$(uname -r)"
+	elif [ -e "/lib/kernel/config-$(uname -r)" ]; then
+		opt_config="/lib/kernel/config-$(uname -r)"
 	fi
 else
 	_info "Checking for vulnerabilities against specified kernel"
@@ -1507,7 +1856,7 @@ if [ "$os" = Linux ]; then
 	fi
 
 	if [ -n "$dumped_config" ] && [ -n "$opt_config" ]; then
-		_verbose "Will use kconfig \033[35m/proc/config.gz (decompressed)\033[0m"
+		_verbose "Will use kconfig \033[35m$procfs/config.gz (decompressed)\033[0m"
 	elif [ -n "$opt_config" ]; then
 		_verbose "Will use kconfig \033[35m$opt_config\033[0m"
 	else
@@ -1523,15 +1872,15 @@ if [ "$os" = Linux ]; then
 	fi
 
 	if [ "$bad_accuracy" = 1 ]; then
-		_info "We're missing some kernel info (see -v), accuracy might be reduced"
+		_warn "We're missing some kernel info (see -v), accuracy might be reduced"
 	fi
 fi
 
 if [ -e "$opt_kernel" ]; then
-	if ! which "${opt_arch_prefix}readelf" >/dev/null 2>&1; then
+	if ! command -v "${opt_arch_prefix}readelf" >/dev/null 2>&1; then
 		_debug "readelf not found"
 		kernel_err="missing '${opt_arch_prefix}readelf' tool, please install it, usually it's in the 'binutils' package"
-	elif [ "$opt_sysfs_only" = 1 ]; then
+	elif [ "$opt_sysfs_only" = 1 ] || [ "$opt_hw_only" = 1 ]; then
 		kernel_err='kernel image decompression skipped'
 	else
 		extract_kernel "$opt_kernel"
@@ -1578,26 +1927,64 @@ _info
 
 sys_interface_check()
 {
-	[ "$opt_live" = 1 ] && [ "$opt_no_sysfs" = 0 ] && [ -r "$1" ] || return 1
+	file="$1"
+	regex="$2"
+	mode="$3"
+	msg=''
+	fullmsg=''
+
+	if [ "$opt_live" = 1 ] && [ "$opt_no_sysfs" = 0 ] && [ -r "$file" ]; then
+		:
+	else
+		mockme=$(printf "%b\n%b" "$mockme" "SMC_MOCK_SYSFS_$(basename "$file")_RET=1")
+		return 1
+	fi
+
+	_mockvarname="SMC_MOCK_SYSFS_$(basename "$file")_RET"
+	# shellcheck disable=SC2086
+	if [ -n "$(eval echo \$$_mockvarname)" ]; then
+		_debug "sysfs: MOCKING enabled for $file func returns $(eval echo \$$_mockvarname)"
+		mocked=1
+		return "$(eval echo \$$_mockvarname)"
+	fi
+
+	[ -n "$regex" ] || regex='.*'
+	_mockvarname="SMC_MOCK_SYSFS_$(basename "$file")"
+	# shellcheck disable=SC2086
+	if [ -n "$(eval echo \$$_mockvarname)" ]; then
+		fullmsg="$(eval echo \$$_mockvarname)"
+		msg=$(echo "$fullmsg" | grep -Eo "$regex")
+		_debug "sysfs: MOCKING enabled for $file, will return $fullmsg"
+		mocked=1
+	else
+		fullmsg=$(cat "$file")
+		msg=$(grep -Eo "$regex" "$file")
+		mockme=$(printf "%b\n%b" "$mockme" "SMC_MOCK_SYSFS_$(basename "$file")='$fullmsg'")
+	fi
+	if [ "$mode" = silent ]; then
+		return 0
+	elif [ "$mode" = quiet ]; then
+		_info "* Information from the /sys interface: $fullmsg"
+		return 0
+	fi
 	_info_nol "* Mitigated according to the /sys interface: "
-	msg=$(cat "$1")
-	if grep -qi '^not affected' "$1"; then
+	if echo "$msg" | grep -qi '^not affected'; then
 		# Not affected
 		status=OK
-		pstatus green YES "$msg"
-	elif grep -qi '^mitigation' "$1"; then
+		pstatus green YES "$fullmsg"
+	elif echo "$msg" | grep -qi '^mitigation'; then
 		# Mitigation: PTI
 		status=OK
-		pstatus green YES "$msg"
-	elif grep -qi '^vulnerable' "$1"; then
+		pstatus green YES "$fullmsg"
+	elif echo "$msg" | grep -qi '^vulnerable'; then
 		# Vulnerable
 		status=VULN
-		pstatus yellow NO "$msg"
+		pstatus yellow NO "$fullmsg"
 	else
 		status=UNK
-		pstatus yellow UNKNOWN "$msg"
+		pstatus yellow UNKNOWN "$fullmsg"
 	fi
-	_debug "sys_interface_check: $1=$msg"
+	_debug "sys_interface_check: $file=$msg (re=$regex)"
 	return 0
 }
 
@@ -1614,90 +2001,128 @@ number_of_cpus()
 	return "$n"
 }
 
-# $1 - msr number
-# $2 - cpu index
+# write_msr
+# param1 (mandatory): MSR, can be in hex or decimal.
+# param2 (optional): CPU index, starting from 0. Default 0.
 write_msr()
 {
-	# _msr must be in hex, in the form 0x1234:
-	_msr="$1"
-	# cpu index, starting from 0:
+	_msr_dec=$(( $1 ))
+	_msr=$(printf "0x%x" "$_msr_dec")
 	_cpu="$2"
+	[ -z "$_cpu" ] && _cpu=0
+
+	_mockvarname="SMC_MOCK_WRMSR_${_msr}_RET"
+	# shellcheck disable=SC2086
+	if [ -n "$(eval echo \$$_mockvarname)" ]; then
+		_debug "write_msr: MOCKING enabled for msr $_msr func returns $(eval echo \$$_mockvarname)"
+		mocked=1
+		return "$(eval echo \$$_mockvarname)"
+	fi
+
 	if [ "$os" != Linux ]; then
 		cpucontrol -m "$_msr=0" "/dev/cpuctl$_cpu" >/dev/null 2>&1; ret=$?
 	else
 		# for Linux
 		# convert to decimal
-		_msr=$(( _msr ))
 		if [ ! -w /dev/cpu/"$_cpu"/msr ]; then
 			ret=200 # permission error
 		# if wrmsr is available, use it
-		elif which wrmsr >/dev/null 2>&1 && [ "$SMC_NO_WRMSR" != 1 ]; then
+		elif command -v wrmsr >/dev/null 2>&1 && [ "$SMC_NO_WRMSR" != 1 ]; then
 			_debug "write_msr: using wrmsr"
-			wrmsr $_msr 0 2>/dev/null; ret=$?
+			wrmsr $_msr_dec 0 2>/dev/null; ret=$?
 		# or if we have perl, use it, any 5.x version will work
-		elif which perl >/dev/null 2>&1 && [ "$SMC_NO_PERL" != 1 ]; then
+		elif command -v perl >/dev/null 2>&1 && [ "$SMC_NO_PERL" != 1 ]; then
 			_debug "write_msr: using perl"
 			ret=1
-			perl -e "open(M,'>','/dev/cpu/$_cpu/msr') and seek(M,$_msr,0) and exit(syswrite(M,pack('H16',0)))"; [ $? -eq 8 ] && ret=0
+			perl -e "open(M,'>','/dev/cpu/$_cpu/msr') and seek(M,$_msr_dec,0) and exit(syswrite(M,pack('H16',0)))"; [ $? -eq 8 ] && ret=0
 		# fallback to dd if it supports seek_bytes
-		elif dd if=/dev/null of=/dev/null bs=8 count=1 seek="$_msr" oflag=seek_bytes 2>/dev/null; then
+		elif dd if=/dev/null of=/dev/null bs=8 count=1 seek="$_msr_dec" oflag=seek_bytes 2>/dev/null; then
 			_debug "write_msr: using dd"
-			dd if=/dev/zero of=/dev/cpu/"$_cpu"/msr bs=8 count=1 seek="$_msr" oflag=seek_bytes 2>/dev/null; ret=$?
+			dd if=/dev/zero of=/dev/cpu/"$_cpu"/msr bs=8 count=1 seek="$_msr_dec" oflag=seek_bytes 2>/dev/null; ret=$?
 		else
 			_debug "write_msr: got no wrmsr, perl or recent enough dd!"
+			mockme=$(printf "%b\n%b" "$mockme" "SMC_MOCK_WRMSR_${_msr}_RET=201")
 			return 201 # missing tool error
 		fi
 	fi
 	# normalize ret
 	[ "$ret" != 0 ] && ret=1
 	_debug "write_msr: for cpu $_cpu on msr $_msr, ret=$ret"
+	mockme=$(printf "%b\n%b" "$mockme" "SMC_MOCK_WRMSR_${_msr}_RET=$ret")
 	return $ret
 }
 
+# read_msr
+# param1 (mandatory): MSR, can be in hex or decimal.
+# param2 (optional): CPU index, starting from 0. Default 0.
 read_msr()
 {
-	# _msr must be in hex, in the form 0x1234:
-	_msr="$1"
-	# cpu index, starting from 0:
+	_msr_dec=$(( $1 ))
+	_msr=$(printf "0x%x" "$_msr_dec")
 	_cpu="$2"
+	[ -z "$_cpu" ] && _cpu=0
+
 	read_msr_value=''
+
+	_mockvarname="SMC_MOCK_RDMSR_${_msr}"
+	# shellcheck disable=SC2086
+	if [ -n "$(eval echo \$$_mockvarname)" ]; then
+		read_msr_value="$(eval echo \$$_mockvarname)"
+		_debug "read_msr: MOCKING enabled for msr $_msr, returning $read_msr_value"
+		mocked=1
+		return 0
+	else
+		mockme=$(printf "%b\n%b" "$mockme" "SMC_MOCK_RDMSR_${_msr}='$read_msr_value'")
+	fi
+
+	_mockvarname="SMC_MOCK_RDMSR_${_msr}_RET"
+	# shellcheck disable=SC2086
+	if [ -n "$(eval echo \$$_mockvarname)" ] && [ "$(eval echo \$$_mockvarname)" -ne 0 ]; then
+		_debug "read_msr: MOCKING enabled for msr $_msr func returns $(eval echo \$$_mockvarname)"
+		mocked=1
+		return "$(eval echo \$$_mockvarname)"
+	fi
+
 	if [ "$os" != Linux ]; then
+		# for BSD
 		_msr=$(cpucontrol -m "$_msr" "/dev/cpuctl$_cpu" 2>/dev/null); ret=$?
-		[ $ret -ne 0 ] && return 1
+		if [ $ret -ne 0 ]; then
+			mockme=$(printf "%b\n%b" "$mockme" "SMC_MOCK_RDMSR_${_msr}_RET=1")
+			return 1
+		fi
 		# MSR 0x10: 0x000003e1 0xb106dded
 		_msr_h=$(echo "$_msr" | awk '{print $3}');
-		_msr_h="$(( _msr_h >> 24 & 0xFF )) $(( _msr_h >> 16 & 0xFF )) $(( _msr_h >> 8 & 0xFF )) $(( _msr_h & 0xFF ))"
 		_msr_l=$(echo "$_msr" | awk '{print $4}');
-		_msr_l="$(( _msr_l >> 24 & 0xFF )) $(( _msr_l >> 16 & 0xFF )) $(( _msr_l >> 8 & 0xFF )) $(( _msr_l & 0xFF ))"
-		read_msr_value="$_msr_h $_msr_l"
+		read_msr_value=$(( _msr_h << 32 | _msr_l ))
 	else
 		# for Linux
-		# convert to decimal
-		_msr=$(( _msr ))
 		if [ ! -r /dev/cpu/"$_cpu"/msr ]; then
+			mockme=$(printf "%b\n%b" "$mockme" "SMC_MOCK_RDMSR_${_msr}_RET=200")
 			return 200 # permission error
 		# if rdmsr is available, use it
-		elif which rdmsr >/dev/null 2>&1 && [ "$SMC_NO_RDMSR" != 1 ]; then
+		elif command -v rdmsr >/dev/null 2>&1 && [ "$SMC_NO_RDMSR" != 1 ]; then
 			_debug "read_msr: using rdmsr"
-			read_msr_value=$(rdmsr -r $_msr 2>/dev/null | od -t u8 -A n)
+			read_msr_value=$(rdmsr -r $_msr_dec 2>/dev/null | od -t u8 -A n)
 		# or if we have perl, use it, any 5.x version will work
-		elif which perl >/dev/null 2>&1 && [ "$SMC_NO_PERL" != 1 ]; then
+		elif command -v perl >/dev/null 2>&1 && [ "$SMC_NO_PERL" != 1 ]; then
 			_debug "read_msr: using perl"
-			read_msr_value=$(perl -e "open(M,'<','/dev/cpu/$_cpu/msr') and seek(M,$_msr,0) and read(M,\$_,8) and print" | od -t u8 -A n)
+			read_msr_value=$(perl -e "open(M,'<','/dev/cpu/$_cpu/msr') and seek(M,$_msr_dec,0) and read(M,\$_,8) and print" | od -t u8 -A n)
 		# fallback to dd if it supports skip_bytes
-		elif dd if=/dev/null of=/dev/null bs=8 count=1 skip="$_msr" iflag=skip_bytes 2>/dev/null; then
+		elif dd if=/dev/null of=/dev/null bs=8 count=1 skip="$_msr_dec" iflag=skip_bytes 2>/dev/null; then
 			_debug "read_msr: using dd"
-			read_msr_value=$(dd if=/dev/cpu/"$_cpu"/msr bs=8 count=1 skip="$_msr" iflag=skip_bytes 2>/dev/null | od -t u8 -A n)
+			read_msr_value=$(dd if=/dev/cpu/"$_cpu"/msr bs=8 count=1 skip="$_msr_dec" iflag=skip_bytes 2>/dev/null | od -t u8 -A n)
 		else
 			_debug "read_msr: got no rdmsr, perl or recent enough dd!"
+			mockme=$(printf "%b\n%b" "$mockme" "SMC_MOCK_RDMSR_${_msr}_RET=201")
 			return 201 # missing tool error
 		fi
 		if [ -z "$read_msr_value" ]; then
 			# MSR doesn't exist, don't check for $? because some versions of dd still return 0!
+			mockme=$(printf "%b\n%b" "$mockme" "SMC_MOCK_RDMSR_${_msr}_RET=1")
 			return 1
 		fi
 	fi
-	_debug "read_msr: MSR=$1 value is $read_msr_value"
+	_debug "read_msr: MSR=$_msr value is $read_msr_value"
 	return 0
 }
 
@@ -1771,7 +2196,7 @@ check_cpu()
 			cpuid_spec_ctrl=1
 			cpuid_ibrs='SPEC_CTRL'
 		fi
-	elif is_amd; then
+	elif is_amd || is_hygon; then
 		read_cpuid 0x80000008 $EBX 14 1 1; ret=$?
 		if [ $ret -eq 0 ]; then
 			pstatus green YES "IBRS_SUPPORT feature bit"
@@ -1788,9 +2213,9 @@ check_cpu()
 		cpuid_spec_ctrl=-1
 	fi
 
-	if is_amd; then
+	if is_amd || is_hygon; then
 		_info_nol "    * CPU indicates preferring IBRS always-on: "
-		# amd
+		# amd or hygon
 		read_cpuid 0x80000008 $EBX 16 1 1; ret=$?
 		if [ $ret -eq 0 ]; then
 			pstatus green YES
@@ -1799,7 +2224,7 @@ check_cpu()
 		fi
 
 		_info_nol "    * CPU indicates preferring IBRS over retpoline: "
-		# amd
+		# amd or hygon
 		read_cpuid 0x80000008 $EBX 18 1 1; ret=$?
 		if [ $ret -eq 0 ]; then
 			pstatus green YES
@@ -1813,6 +2238,8 @@ check_cpu()
 	_info_nol "    * PRED_CMD MSR is available: "
 	if [ ! -e /dev/cpu/0/msr ] && [ ! -e /dev/cpuctl0 ]; then
 		pstatus yellow UNKNOWN "is msr kernel module available?"
+	elif [ ! -r /dev/cpu/0/msr ] && [ ! -w /dev/cpuctl0 ]; then
+		pstatus yellow UNKNOWN "are you root?"
 	else
 		# the new MSR 'PRED_CTRL' is at offset 0x49, write-only
 		# we test if of all cpus
@@ -1857,7 +2284,7 @@ check_cpu()
 		else
 			pstatus yellow NO
 		fi
-	elif is_amd; then
+	elif is_amd || is_hygon; then
 		read_cpuid 0x80000008 $EBX 12 1 1; ret=$?
 		if [ $ret -eq 0 ]; then
 			cpuid_ibpb='IBPB_SUPPORT'
@@ -1895,6 +2322,12 @@ check_cpu()
 			pstatus green YES "AMD STIBP feature bit"
 			#cpuid_stibp='AMD STIBP'
 		fi
+	elif is_hygon; then
+		read_cpuid 0x80000008 $EBX 15 1 1; ret=$?
+		if [ $ret -eq 0 ]; then
+			pstatus green YES "HYGON STIBP feature bit"
+			#cpuid_stibp='HYGON STIBP'
+		fi
 	else
 		ret=-1
 		pstatus yellow UNKNOWN "unknown CPU"
@@ -1906,7 +2339,7 @@ check_cpu()
 	fi
 
 
-	if is_amd; then
+	if is_amd || is_hygon; then
 		_info_nol "    * CPU indicates preferring STIBP always-on: "
 		read_cpuid 0x80000008 $EBX 17 1 1; ret=$?
 		if [ $ret -eq 0 ]; then
@@ -1920,8 +2353,8 @@ check_cpu()
 	if is_intel; then
 		_info     "  * Speculative Store Bypass Disable (SSBD)"
 		_info_nol "    * CPU indicates SSBD capability: "
-		read_cpuid 0x7 $EDX 31 1 1; ret=$?
-		if [ $ret -eq 0 ]; then
+		read_cpuid 0x7 $EDX 31 1 1; ret24=$?; ret25=$ret24
+		if [ $ret24 -eq 0 ]; then
 			cpuid_ssbd='Intel SSBD'
 		fi
 	elif is_amd; then
@@ -1937,6 +2370,21 @@ check_cpu()
 			#cpuid_ssbd_virt_spec_ctrl=1
 		elif [ "$cpu_family" -ge 21 ] && [ "$cpu_family" -le 23 ]; then
 			cpuid_ssbd='AMD non-architectural MSR'
+		fi
+	elif is_hygon; then
+		_info     "  * Speculative Store Bypass Disable (SSBD)"
+		_info_nol "    * CPU indicates SSBD capability: "
+		read_cpuid 0x80000008 $EBX 24 1 1; ret24=$?
+		read_cpuid 0x80000008 $EBX 25 1 1; ret25=$?
+		
+		if [ $ret24 -eq 0 ]; then
+			cpuid_ssbd='HYGON SSBD in SPEC_CTRL'
+			#hygon cpuid_ssbd_spec_ctrl=1
+		elif [ $ret25 -eq 0 ]; then
+			cpuid_ssbd='HYGON SSBD in VIRT_SPEC_CTRL'
+			#hygon cpuid_ssbd_virt_spec_ctrl=1
+		elif [ "$cpu_family" -ge 24 ]; then
+			cpuid_ssbd='HYGON non-architectural MSR'
 		fi
 	fi
 
@@ -1954,12 +2402,21 @@ check_cpu()
 		if [ $ret -eq 0 ]; then
 			amd_ssb_no=1
 		fi
+	elif is_hygon; then
+		# indicate when speculative store bypass disable is no longer needed to prevent speculative loads bypassing older stores
+		read_cpuid 0x80000008 $EBX 26 1 1; ret=$?
+		if [ $ret -eq 0 ]; then
+			hygon_ssb_no=1
+			_debug "hygon_ssb_no=1"
+		fi
 	fi
 
 	_info "  * L1 data cache invalidation"
 	_info_nol "    * FLUSH_CMD MSR is available: "
 	if [ ! -e /dev/cpu/0/msr ] && [ ! -e /dev/cpuctl0 ]; then
 		pstatus yellow UNKNOWN "is msr kernel module available?"
+	elif [ ! -r /dev/cpu/0/msr ] && [ ! -w /dev/cpuctl0 ]; then
+		pstatus yellow UNKNOWN "are you root?"
 	else
 		# the new MSR 'FLUSH_CMD' is at offset 0x10b, write-only
 		# we test if of all cpus
@@ -1982,12 +2439,39 @@ check_cpu()
 		if [ $val -eq 0 ]; then
 			if [ $cpu_mismatch -eq 0 ]; then
 				pstatus green YES
+				cpu_flush_cmd=1
 			else
 				pstatus green YES "But not in all CPUs"
 			fi
 		elif [ $val -eq 200 ]; then
 			pstatus yellow UNKNOWN "is msr kernel module available?"
 		else
+			pstatus yellow NO
+		fi
+	fi
+	# CPUID of L1D
+	_info_nol "    * CPU indicates L1D flush capability: "
+	read_cpuid 0x7 $EDX 28 1 1; ret=$?
+	if [ $ret -eq 0 ]; then
+		pstatus green YES "L1D flush feature bit"
+	elif [ $ret -eq 1 ]; then
+		pstatus yellow NO
+	elif [ $ret -eq 2 ]; then
+		pstatus yellow UNKNOWN "is cpuid kernel module available?"
+	fi
+
+	if is_intel; then
+		_info "  * Microarchitecture Data Sampling"
+		_info_nol "    * VERW instruction is available: "
+		read_cpuid 0x7 $EDX 10 1 1; ret=$?
+		if [ $ret -eq 0 ]; then
+			cpuid_md_clear=1
+			pstatus green YES "MD_CLEAR feature bit"
+		elif [ $ret -eq 2 ]; then
+			cpuid_md_clear=-1
+			pstatus yellow UNKNOWN "is cpuid kernel module available?"
+		else
+			cpuid_md_clear=0
 			pstatus yellow NO
 		fi
 	fi
@@ -2009,17 +2493,21 @@ check_cpu()
 		fi
 
 		_info_nol "    * ARCH_CAPABILITIES MSR advertises IBRS_ALL capability: "
+		capabilities_mds_no=-1
 		capabilities_rdcl_no=-1
 		capabilities_ibrs_all=-1
-		capabilities_ssb_no=-1
 		capabilities_rsba=-1
+		capabilities_l1dflush_no=-1
+		capabilities_ssb_no=-1
 		if [ "$cpuid_arch_capabilities" = -1 ]; then
 			pstatus yellow UNKNOWN
 		elif [ "$cpuid_arch_capabilities" != 1 ]; then
 			capabilities_rdcl_no=0
+			capabilities_mds_no=0
 			capabilities_ibrs_all=0
-			capabilities_ssb_no=0
 			capabilities_rsba=0
+			capabilities_l1dflush_no=0
+			capabilities_ssb_no=0
 			pstatus yellow NO
 		elif [ ! -e /dev/cpu/0/msr ] && [ ! -e /dev/cpuctl0 ]; then
 			spec_ctrl_msr=-1
@@ -2047,16 +2535,20 @@ check_cpu()
 			done
 			capabilities=$val_cap_msr
 			capabilities_rdcl_no=0
+			capabilities_mds_no=0
 			capabilities_ibrs_all=0
-			capabilities_ssb_no=0
 			capabilities_rsba=0
+			capabilities_l1dflush_no=0
+			capabilities_ssb_no=0
 			if [ $val -eq 0 ]; then
 				_debug "capabilities MSR is $capabilities (decimal)"
 				[ $(( capabilities >> 0 & 1 )) -eq 1 ] && capabilities_rdcl_no=1
 				[ $(( capabilities >> 1 & 1 )) -eq 1 ] && capabilities_ibrs_all=1
 				[ $(( capabilities >> 2 & 1 )) -eq 1 ] && capabilities_rsba=1
+				[ $(( capabilities >> 3 & 1 )) -eq 1 ] && capabilities_l1dflush_no=1
 				[ $(( capabilities >> 4 & 1 )) -eq 1 ] && capabilities_ssb_no=1
-				_debug "capabilities says rdcl_no=$capabilities_rdcl_no ibrs_all=$capabilities_ibrs_all ssb_no=$capabilities_ssb_no rsba=$capabilities_rsba"
+				[ $(( capabilities >> 5 & 1 )) -eq 1 ] && capabilities_mds_no=1
+				_debug "capabilities says rdcl_no=$capabilities_rdcl_no ibrs_all=$capabilities_ibrs_all rsba=$capabilities_rsba l1dflush_no=$capabilities_l1dflush_no ssb_no=$capabilities_ssb_no mds_no=$capabilities_mds_no"
 				if [ "$capabilities_ibrs_all" = 1 ]; then
 					if [ $cpu_mismatch -eq 0 ]; then
 						pstatus green YES
@@ -2075,7 +2567,7 @@ check_cpu()
 			fi
 		fi
 
-		_info_nol "  * CPU explicitly indicates not being vulnerable to Meltdown (RDCL_NO): "
+		_info_nol "  * CPU explicitly indicates not being vulnerable to Meltdown/L1TF (RDCL_NO): "
 		if [ "$capabilities_rdcl_no" = -1 ]; then
 			pstatus yellow UNKNOWN
 		elif [ "$capabilities_rdcl_no" = 1 ]; then
@@ -2083,24 +2575,58 @@ check_cpu()
 		else
 			pstatus yellow NO
 		fi
+
+		_info_nol "  * CPU explicitly indicates not being vulnerable to Variant 4 (SSB_NO): "
+		if [ "$capabilities_ssb_no" = -1 ]; then
+			pstatus yellow UNKNOWN
+		elif [ "$capabilities_ssb_no" = 1 ] || [ "$amd_ssb_no" = 1 ] || [ "$hygon_ssb_no" = 1 ]; then
+			pstatus green YES
+		else
+			pstatus yellow NO
+		fi
+
+		_info_nol "  * CPU/Hypervisor indicates L1D flushing is not necessary on this system: "
+		if [ "$capabilities_l1dflush_no" = -1 ]; then
+			pstatus yellow UNKNOWN
+		elif [ "$capabilities_l1dflush_no" = 1 ]; then
+			pstatus green YES
+		else
+			pstatus yellow NO
+		fi
+
+		_info_nol "  * Hypervisor indicates host CPU might be vulnerable to RSB underflow (RSBA): "
+		if [ "$capabilities_rsba" = -1 ]; then
+			pstatus yellow UNKNOWN
+		elif [ "$capabilities_rsba" = 1 ]; then
+			pstatus yellow YES
+		else
+			pstatus blue NO
+		fi
+
+		_info_nol "  * CPU explicitly indicates not being vulnerable to Microarchitectural Data Sampling (MDS_NO): "
+		if [ "$capabilities_mds_no" = -1 ]; then
+			pstatus yellow UNKNOWN
+		elif [ "$capabilities_mds_no" = 1 ]; then
+			pstatus green YES
+		else
+			pstatus yellow NO
+		fi
 	fi
 
-	_info_nol "  * CPU explicitly indicates not being vulnerable to Variant 4 (SSB_NO): "
-	if [ "$capabilities_ssb_no" = -1 ]; then
-		pstatus yellow UNKNOWN
-	elif [ "$capabilities_ssb_no" = 1 ] || [ "$amd_ssb_no" = 1 ]; then
-		pstatus green YES
-	else
-		pstatus yellow NO
+	_info_nol "  * CPU supports Software Guard Extensions (SGX): "
+	ret=1
+	cpuid_sgx=0
+	if is_intel; then
+		read_cpuid 0x7 $EBX 2 1 1; ret=$?
 	fi
-
-	_info_nol "  * Hypervisor indicates host CPU might be vulnerable to RSB underflow (RSBA): "
-	if [ "$capabilities_rsba" = -1 ]; then
-		pstatus yellow UNKNOWN
-	elif [ "$capabilities_rsba" = 1 ]; then
-		pstatus yellow YES
+	if [ $ret -eq 0 ]; then
+		pstatus blue YES
+		cpuid_sgx=1
+	elif [ $ret -eq 2 ]; then
+		pstatus yellow UNKNOWN "is cpuid kernel module available?"
+		cpuid_sgx=-1
 	else
-		pstatus blue NO
+		pstatus green NO
 	fi
 
 	_info_nol "  * CPU microcode is known to cause stability problems: "
@@ -2130,9 +2656,9 @@ check_cpu()
 check_cpu_vulnerabilities()
 {
 	_info     "* CPU vulnerability to the speculative execution attack variants"
-	for v in 1 2 3 3a 4 l1tf; do
-		_info_nol "  * Vulnerable to Variant $v: "
-		if is_cpu_vulnerable $v; then
+	for cve in $supported_cve_list; do
+		_info_nol "  * Vulnerable to $cve ($(cve2name "$cve")): "
+		if is_cpu_vulnerable "$cve"; then
 			pstatus yellow YES
 		else
 			pstatus green NO
@@ -2145,7 +2671,7 @@ check_redhat_canonical_spectre()
 	# if we were already called, don't do it again
 	[ -n "$redhat_canonical_spectre" ] && return
 
-	if ! which "${opt_arch_prefix}strings" >/dev/null 2>&1; then
+	if ! command -v "${opt_arch_prefix}strings" >/dev/null 2>&1; then
 		redhat_canonical_spectre=-1
 	elif [ -n "$kernel_err" ]; then
 		redhat_canonical_spectre=-2
@@ -2168,22 +2694,24 @@ check_redhat_canonical_spectre()
 	fi
 }
 
-
 ###################
-# SPECTRE VARIANT 1
-check_variant1()
+# SPECTRE 1 SECTION
+
+# bounds check bypass aka 'Spectre Variant 1'
+check_CVE_2017_5753()
 {
-	_info "\033[1;34mCVE-2017-5753 [bounds check bypass] aka 'Spectre Variant 1'\033[0m"
+	cve='CVE-2017-5753'
+	_info "\033[1;34m$cve aka '$(cve2name "$cve")'\033[0m"
 	if [ "$os" = Linux ]; then
-		check_variant1_linux
+		check_CVE_2017_5753_linux
 	elif echo "$os" | grep -q BSD; then
-		check_variant1_bsd
+		check_CVE_2017_5753_bsd
 	else
 		_warn "Unsupported OS ($os)"
 	fi
 }
 
-check_variant1_linux()
+check_CVE_2017_5753_linux()
 {
 	status=UNK
 	sys_interface_available=0
@@ -2227,7 +2755,7 @@ check_variant1_linux()
 		# http://git.arm.linux.org.uk/cgit/linux-arm.git/commit/?h=spectre&id=a78d156587931a2c3b354534aa772febf6c9e855
 		if [ -n "$kernel_err" ]; then
 			pstatus yellow UNKNOWN "couldn't check ($kernel_err)"
-		elif ! which perl >/dev/null 2>&1; then
+		elif ! command -v perl >/dev/null 2>&1; then
 			pstatus yellow UNKNOWN "missing 'perl' binary, please install it"
 		else
 			perl -ne '/\x0f\x83....\x48\x19\xd2\x48\x21\xd0/ and $found++; END { exit($found) }' "$kernel"; ret=$?
@@ -2284,9 +2812,9 @@ check_variant1_linux()
 			pstatus yellow NO
 		elif [ -n "$kernel_err" ]; then
 			pstatus yellow UNKNOWN "couldn't check ($kernel_err)"
-		elif ! which perl >/dev/null 2>&1; then
+		elif ! command -v perl >/dev/null 2>&1; then
 			pstatus yellow UNKNOWN "missing 'perl' binary, please install it"
-		elif ! which "${opt_arch_prefix}objdump" >/dev/null 2>&1; then
+		elif ! command -v "${opt_arch_prefix}objdump" >/dev/null 2>&1; then
 			pstatus yellow UNKNOWN "missing '${opt_arch_prefix}objdump' tool, please install it, usually it's in the binutils package"
 		else
 			"${opt_arch_prefix}objdump" -d "$kernel" | perl -ne 'push @r, $_; /\s(hint|csdb)\s/ && $r[0]=~/\ssub\s+(x\d+)/ && $r[1]=~/\sbic\s+$1,\s+$1,/ && $r[2]=~/\sand\s/ && exit(9); shift @r if @r>3'; ret=$?
@@ -2298,14 +2826,14 @@ check_variant1_linux()
 			fi
 		fi
 
-		if [ "$opt_verbose" -ge 2 ] || ( [ -z "$v1_mask_nospec" ] && [ "$redhat_canonical_spectre" != 1 ] && [ "$redhat_canonical_spectre" != 2 ] ); then
+		if [ "$opt_verbose" -ge 2 ] || { [ -z "$v1_mask_nospec" ] && [ "$redhat_canonical_spectre" != 1 ] && [ "$redhat_canonical_spectre" != 2 ]; }; then
 			# this is a slow heuristic and we don't need it if we already know the kernel is patched
 			# but still show it in verbose mode
 			_info_nol "* Checking count of LFENCE instructions following a jump in kernel... "
 			if [ -n "$kernel_err" ]; then
 				pstatus yellow UNKNOWN "couldn't check ($kernel_err)"
 			else
-				if ! which "${opt_arch_prefix}objdump" >/dev/null 2>&1; then
+				if ! command -v "${opt_arch_prefix}objdump" >/dev/null 2>&1; then
 					pstatus yellow UNKNOWN "missing '${opt_arch_prefix}objdump' tool, please install it, usually it's in the binutils package"
 				else
 					# here we disassemble the kernel and count the number of occurrences of the LFENCE opcode
@@ -2333,9 +2861,7 @@ check_variant1_linux()
 	fi
 
 	# report status
-	cve='CVE-2017-5753'
-
-	if ! is_cpu_vulnerable 1; then
+	if ! is_cpu_vulnerable "$cve"; then
 		# override status & msg in case CPU is not vulnerable after all
 		pvulnstatus $cve OK "your CPU vendor reported your CPU model as not vulnerable"
 	elif [ -z "$msg" ]; then
@@ -2346,7 +2872,7 @@ check_variant1_linux()
 			pvulnstatus $cve OK "Kernel source has been patched to mitigate the vulnerability (Red Hat/Ubuntu patch)"
 		elif [ "$v1_lfence" = 1 ]; then
 			pvulnstatus $cve OK "Kernel source has PROBABLY been patched to mitigate the vulnerability (jump-then-lfence instructions heuristic)"
-		elif [ "$kernel_err" ]; then
+		elif [ -n "$kernel_err" ]; then
 			pvulnstatus $cve UNK "Couldn't find kernel image or tools missing to execute the checks"
 			explain "Re-run this script with root privileges, after installing the missing tools indicated above"
 		else
@@ -2368,10 +2894,9 @@ check_variant1_linux()
 	fi
 }
 
-check_variant1_bsd()
+check_CVE_2017_5753_bsd()
 {
-	cve='CVE-2017-5753'
-	if ! is_cpu_vulnerable 1; then
+	if ! is_cpu_vulnerable "$cve"; then
 		# override status & msg in case CPU is not vulnerable after all
 		pvulnstatus $cve OK "your CPU vendor reported your CPU model as not vulnerable"
 	else
@@ -2379,22 +2904,24 @@ check_variant1_bsd()
 	fi
 }
 
-
 ###################
-# SPECTRE VARIANT 2
-check_variant2()
+# SPECTRE 2 SECTION
+
+# branch target injection aka 'Spectre Variant 2'
+check_CVE_2017_5715()
 {
-	_info "\033[1;34mCVE-2017-5715 [branch target injection] aka 'Spectre Variant 2'\033[0m"
+	cve='CVE-2017-5715'
+	_info "\033[1;34m$cve aka '$(cve2name "$cve")'\033[0m"
 	if [ "$os" = Linux ]; then
-		check_variant2_linux
+		check_CVE_2017_5715_linux
 	elif echo "$os" | grep -q BSD; then
-		check_variant2_bsd
+		check_CVE_2017_5715_bsd
 	else
 		_warn "Unsupported OS ($os)"
 	fi
 }
 
-check_variant2_linux()
+check_CVE_2017_5715_linux()
 {
 	status=UNK
 	sys_interface_available=0
@@ -2421,7 +2948,7 @@ check_variant2_linux()
 			for dir in \
 				/sys/kernel/debug \
 				/sys/kernel/debug/x86 \
-				/proc/sys/kernel; do
+				"$procfs/sys/kernel"; do
 				if [ -e "$dir/ibrs_enabled" ]; then
 					# if the file is there, we have IBRS compiled-in
 					# /sys/kernel/debug/ibrs_enabled: vanilla
@@ -2458,24 +2985,33 @@ check_variant2_linux()
 					# XXX and what about ibpb ?
 				fi
 			fi
-			if [ -e "/sys/devices/system/cpu/vulnerabilities/spectre_v2" ]; then
+			if [ -n "$fullmsg" ]; then
 				# when IBPB is enabled on 4.15+, we can see it in sysfs
-				if grep -q 'IBPB' "/sys/devices/system/cpu/vulnerabilities/spectre_v2"; then
+				if echo "$fullmsg" | grep -q 'IBPB'; then
 					_debug "ibpb: found enabled in sysfs"
 					[ -z "$ibpb_supported" ] && ibpb_supported='IBPB found enabled in sysfs'
 					[ -z "$ibpb_enabled"   ] && ibpb_enabled=1
 				fi
 				# when IBRS_FW is enabled on 4.15+, we can see it in sysfs
-				if grep -q ', IBRS_FW' "/sys/devices/system/cpu/vulnerabilities/spectre_v2"; then
+				if echo "$fullmsg" | grep -q ', IBRS_FW'; then
 					_debug "ibrs: found IBRS_FW in sysfs"
 					[ -z "$ibrs_supported" ] && ibrs_supported='found IBRS_FW in sysfs'
 					ibrs_fw_enabled=1
 				fi
 				# when IBRS is enabled on 4.15+, we can see it in sysfs
-				if grep -q -e 'IBRS' -e 'Indirect Branch Restricted Speculation' "/sys/devices/system/cpu/vulnerabilities/spectre_v2"; then
+				# on a more recent kernel, classic "IBRS" is not even longer an option, because of the performance impact.
+				# only "Enhanced IBRS" is available (on CPUs with the IBRS_ALL flag)
+				if echo "$fullmsg" | grep -q -e '\<IBRS\>' -e 'Indirect Branch Restricted Speculation'; then
 					_debug "ibrs: found IBRS in sysfs"
 					[ -z "$ibrs_supported" ] && ibrs_supported='found IBRS in sysfs'
 					[ -z "$ibrs_enabled"   ] && ibrs_enabled=3
+				fi
+				# checking for 'Enhanced IBRS' in sysfs, enabled on CPUs with IBRS_ALL
+				if echo "$fullmsg" | grep -q -e 'Enhanced IBRS'; then
+					[ -z "$ibrs_supported" ] && ibrs_supported='found Enhanced IBRS in sysfs'
+					# 4 isn't actually a valid value of the now extinct "ibrs_enabled" flag file,
+					# that only went from 0 to 3, so we use 4 as "enhanced ibrs is enabled"
+					ibrs_enabled=4
 				fi
 			fi
 			# in live mode, if ibrs or ibpb is supported and we didn't find these are enabled, then they are not
@@ -2490,7 +3026,7 @@ check_variant2_linux()
 			fi
 		fi
 		if [ -z "$ibrs_supported" ] && [ -n "$kernel" ]; then
-			if ! which "${opt_arch_prefix}strings" >/dev/null 2>&1; then
+			if ! command -v "${opt_arch_prefix}strings" >/dev/null 2>&1; then
 				:
 			else
 				ibrs_can_tell=1
@@ -2511,7 +3047,7 @@ check_variant2_linux()
 		# recent (4.15) vanilla kernels have IBPB but not IBRS, and without the debugfs tunables of Red Hat
 		# we can detect it directly in the image
 		if [ -z "$ibpb_supported" ] && [ -n "$kernel" ]; then
-			if ! which "${opt_arch_prefix}strings" >/dev/null 2>&1; then
+			if ! command -v "${opt_arch_prefix}strings" >/dev/null 2>&1; then
 				:
 			else
 				ibpb_can_tell=1
@@ -2549,6 +3085,7 @@ check_variant2_linux()
 				# 1 is enabled only for kernel space
 				# 2 is enabled for kernel and user space
 				# 3 is enabled
+				# 4 is enhanced ibrs enabled
 				case "$ibrs_enabled" in
 					0)
 						if [ "$ibrs_fw_enabled" = 1 ]; then
@@ -2560,6 +3097,7 @@ check_variant2_linux()
 					1)	if [ "$ibrs_fw_enabled" = 1 ]; then pstatus green YES "for kernel space and firmware code"; else pstatus green YES "for kernel space"; fi;;
 					2)	if [ "$ibrs_fw_enabled" = 1 ]; then pstatus green YES "for kernel, user space, and firmware code" ; else pstatus green YES "for both kernel and user space"; fi;;
 					3)	if [ "$ibrs_fw_enabled" = 1 ]; then pstatus green YES "for kernel and firmware code"; else pstatus green YES; fi;;
+					4)	pstatus green YES "Enhanced flavor, performance impact will be greatly reduced";;
 					*)	if [ "$cpuid_ibrs" != 'SPEC_CTRL' ] && [ "$cpuid_ibrs" != 'IBRS_SUPPORT' ] && [ "$cpuid_spec_ctrl" != -1 ]; 
 							then pstatus yellow NO; _debug "ibrs: known cpu not supporting SPEC-CTRL or IBRS"; 
 						else 
@@ -2657,9 +3195,9 @@ check_variant2_linux()
 			#
 			# if there is "retpoline" in the file and NOT "minimal", then it's full retpoline
 			# (works for vanilla and Red Hat variants)
-			if [ "$opt_live" = 1 ] && [ -e "/sys/devices/system/cpu/vulnerabilities/spectre_v2" ]; then
-				if grep -qwi retpoline /sys/devices/system/cpu/vulnerabilities/spectre_v2; then
-					if grep -qwi minimal /sys/devices/system/cpu/vulnerabilities/spectre_v2; then
+			if [ "$opt_live" = 1 ] && [ -n "$fullmsg" ]; then
+				if echo "$fullmsg" | grep -qwi retpoline; then
+					if echo "$fullmsg" | grep -qwi minimal; then
 						retpoline_compiler=0
 						retpoline_compiler_reason="kernel reports minimal retpoline compilation"
 					else
@@ -2675,7 +3213,7 @@ check_variant2_linux()
 				fi
 			elif [ -n "$kernel" ]; then
 				# look for the symbol
-				if which "${opt_arch_prefix}nm" >/dev/null 2>&1; then
+				if command -v "${opt_arch_prefix}nm" >/dev/null 2>&1; then
 					# the proper way: use nm and look for the symbol
 					if "${opt_arch_prefix}nm" "$kernel" 2>/dev/null | grep -qw 'noretpoline_setup'; then
 						retpoline_compiler=1
@@ -2723,7 +3261,7 @@ check_variant2_linux()
 		# only for information, in verbose mode
 		if [ "$opt_verbose" -ge 2 ]; then
 			_info_nol "    * Local gcc is retpoline-aware: "
-			if which gcc >/dev/null 2>&1; then
+			if command -v gcc >/dev/null 2>&1; then
 				if [ -n "$(gcc -mindirect-branch=thunk-extern --version 2>&1 >/dev/null)" ]; then
 					pstatus blue NO
 				else
@@ -2736,7 +3274,7 @@ check_variant2_linux()
 
 		if is_vulnerable_to_empty_rsb || [ "$opt_verbose" -ge 2 ]; then
 			_info_nol "  * Kernel supports RSB filling: "
-			if ! which "${opt_arch_prefix}strings" >/dev/null 2>&1; then
+			if ! command -v "${opt_arch_prefix}strings" >/dev/null 2>&1; then
 				pstatus yellow UNKNOWN "missing '${opt_arch_prefix}strings' tool, please install it, usually it's in the binutils package"
 			elif [ -z "$kernel" ]; then
 				pstatus yellow UNKNOWN "kernel image missing"
@@ -2756,8 +3294,7 @@ check_variant2_linux()
 		status=UNK
 	fi
 
-	cve='CVE-2017-5715'
-	if ! is_cpu_vulnerable 2; then
+	if ! is_cpu_vulnerable "$cve"; then
 		# override status & msg in case CPU is not vulnerable after all
 		pvulnstatus $cve OK "your CPU vendor reported your CPU model as not vulnerable"
 	else
@@ -2771,7 +3308,11 @@ check_variant2_linux()
 				_warn "IBPB is considered as a good addition to retpoline for Variant 2 mitigation, but your CPU microcode doesn't support it"
 			fi
 		elif [ -n "$ibrs_enabled" ] && [ -n "$ibpb_enabled" ] && [ "$ibrs_enabled" -ge 1 ] && [ "$ibpb_enabled" -ge 1 ]; then
-			pvulnstatus $cve OK "IBRS + IBPB are mitigating the vulnerability"
+			if [ "$ibrs_enabled" = 4 ]; then
+				pvulnstatus $cve OK "Enhanced IBRS + IBPB are mitigating the vulnerability"
+			else
+				pvulnstatus $cve OK "IBRS + IBPB are mitigating the vulnerability"
+			fi
 		elif [ "$ibpb_enabled" = 2 ] && ! is_cpu_smt_enabled; then
 			pvulnstatus $cve OK "Full IBPB is mitigating the vulnerability"
 		elif [ -n "$bp_harden" ]; then
@@ -2794,12 +3335,12 @@ check_variant2_linux()
 		if [ "$pvulnstatus_last_cve" != "$cve" ]; then
 			# explain what's needed for this CPU
 			if is_vulnerable_to_empty_rsb; then
-				pvulnstatus $cve VULN "IBRS+IBPB or retpoline+IBPB+RBS filling, is needed to mitigate the vulnerability"
+				pvulnstatus $cve VULN "IBRS+IBPB or retpoline+IBPB+RSB filling, is needed to mitigate the vulnerability"
 				explain "To mitigate this vulnerability, you need either IBRS + IBPB, both requiring hardware support from your CPU microcode in addition to kernel support, or a kernel compiled with retpoline and IBPB, with retpoline requiring a retpoline-aware compiler (re-run this script with -v to know if your version of gcc is retpoline-aware) and IBPB requiring hardware support from your CPU microcode. You also need a recent-enough kernel that supports RSB filling if you plan to use retpoline. For Skylake+ CPUs, the IBRS + IBPB approach is generally preferred as it guarantees complete protection, and the performance impact is not as high as with older CPUs in comparison with retpoline. More information about how to enable the missing bits for those two possible mitigations on your system follow. You only need to take one of the two approaches."
-			elif is_zen_cpu; then
+			elif is_zen_cpu || is_moksha_cpu; then
 				pvulnstatus $cve VULN "retpoline+IBPB is needed to mitigate the vulnerability"
 				explain "To mitigate this vulnerability, You need a kernel compiled with retpoline + IBPB support, with retpoline requiring a retpoline-aware compiler (re-run this script with -v to know if your version of gcc is retpoline-aware) and IBPB requiring hardware support from your CPU microcode."
-			elif is_intel || is_amd; then
+			elif is_intel || is_amd || is_hygon; then
 				pvulnstatus $cve VULN "IBRS+IBPB or retpoline+IBPB is needed to mitigate the vulnerability"
 				explain "To mitigate this vulnerability, you need either IBRS + IBPB, both requiring hardware support from your CPU microcode in addition to kernel support, or a kernel compiled with retpoline and IBPB, with retpoline requiring a retpoline-aware compiler (re-run this script with -v to know if your version of gcc is retpoline-aware) and IBPB requiring hardware support from your CPU microcode. The retpoline + IBPB approach is generally preferred as the performance impact is lower. More information about how to enable the missing bits for those two possible mitigations on your system follow. You only need to take one of the two approaches."
 			else
@@ -2815,9 +3356,9 @@ check_variant2_linux()
 
 		# if we are in live mode, we can check for a lot more stuff and explain further
 		if [ "$opt_live" = 1 ] && [ "$vulnstatus" != "OK" ]; then
-			_explain_hypervisor="An updated CPU microcode will have IBRS/IBPB capabilities indicated in the Hardware Check section above. If you're running under an hypervisor (KVM, Xen, VirtualBox, VMware, ...), the hypervisor needs to be up to date to be able to export the new host CPU flags to the guest. You can run this script on the host to check if the host CPU is IBRS/IBPB. If it is, and it doesn't show up in the guest, upgrade the hypervisor. You may need to reconfigure your VM to use a CPU model that has IBRS capability; in Libvirt, such CPUs are listed with an IBRS suffix."
+			_explain_hypervisor="An updated CPU microcode will have IBRS/IBPB capabilities indicated in the Hardware Check section above. If you're running under a hypervisor (KVM, Xen, VirtualBox, VMware, ...), the hypervisor needs to be up to date to be able to export the new host CPU flags to the guest. You can run this script on the host to check if the host CPU is IBRS/IBPB. If it is, and it doesn't show up in the guest, upgrade the hypervisor. You may need to reconfigure your VM to use a CPU model that has IBRS capability; in Libvirt, such CPUs are listed with an IBRS suffix."
 			# IBPB (amd & intel)
-			if ( [ -z "$ibpb_enabled" ] || [ "$ibpb_enabled" = 0 ] ) && ( is_intel || is_amd ); then
+			if { [ -z "$ibpb_enabled" ] || [ "$ibpb_enabled" = 0 ]; } && { is_intel || is_amd || is_hygon; }; then
 				if [ -z "$cpuid_ibpb" ]; then
 					explain "The microcode of your CPU needs to be upgraded to be able to use IBPB. This is usually done at boot time by your kernel (the upgrade is not persistent across reboots which is why it's done at each boot). If you're using a distro, make sure you are up to date, as microcode updates are usually shipped alongside with the distro kernel. Availability of a microcode update for you CPU model depends on your CPU vendor. You can usually find out online if a microcode update is available for your CPU by searching for your CPUID (indicated in the Hardware Check section). $_explain_hypervisor"
 				fi
@@ -2842,7 +3383,7 @@ check_variant2_linux()
 			# /IBPB
 
 			# IBRS (amd & intel)
-			if ( [ -z "$ibrs_enabled" ] || [ "$ibrs_enabled" = 0 ] ) && ( is_intel || is_amd ); then
+			if { [ -z "$ibrs_enabled" ] || [ "$ibrs_enabled" = 0 ]; } && { is_intel || is_amd || is_hygon; }; then
 				if [ -z "$cpuid_ibrs" ]; then
 					explain "The microcode of your CPU needs to be upgraded to be able to use IBRS. This is usually done at boot time by your kernel (the upgrade is not persistent across reboots which is why it's done at each boot). If you're using a distro, make sure you are up to date, as microcode updates are usually shipped alongside with the distro kernel. Availability of a microcode update for you CPU model depends on your CPU vendor. You can usually find out online if a microcode update is available for your CPU by searching for your CPUID (indicated in the Hardware Check section). $_explain_hypervisor"
 				fi
@@ -2860,8 +3401,8 @@ check_variant2_linux()
 			# /IBRS
 			unset _explain_hypervisor
 
-			# RETPOLINE (amd & intel)
-			if is_amd || is_intel; then
+			# RETPOLINE (amd & intel &hygon )
+			if is_amd || is_intel || is_hygon; then
 				if [ "$retpoline" = 0 ]; then
 					explain "Your kernel is not compiled with retpoline support, so you need to either upgrade your kernel (if you're using a distro) or recompile your kernel with the CONFIG_RETPOLINE option enabled. You also need to compile your kernel with  a retpoline-aware compiler (re-run this script with -v to know if your version of gcc is retpoline-aware)."
 				elif [ "$retpoline" = 1 ] && [ "$retpoline_compiler" = 0 ]; then
@@ -2894,7 +3435,7 @@ check_variant2_linux()
 	# "Mitigation: IBP disabled",
 }
 
-check_variant2_bsd()
+check_CVE_2017_5715_bsd()
 {
 	_info     "* Mitigation 1"
 	_info_nol "  * Kernel supports IBRS: "
@@ -2918,7 +3459,7 @@ check_variant2_bsd()
 	if [ -n "$kernel_err" ]; then
 		pstatus yellow UNKNOWN "couldn't check ($kernel_err)"
 	else
-		if ! which "${opt_arch_prefix}readelf" >/dev/null 2>&1; then
+		if ! command -v "${opt_arch_prefix}readelf" >/dev/null 2>&1; then
 			pstatus yellow UNKNOWN "missing '${opt_arch_prefix}readelf' tool, please install it, usually it's in the binutils package"
 		else
 			nb_thunks=$("${opt_arch_prefix}readelf" -s "$kernel" | grep -c -e __llvm_retpoline_ -e __llvm_external_retpoline_ -e __x86_indirect_thunk_)
@@ -2931,8 +3472,7 @@ check_variant2_bsd()
 		fi
 	fi
 
-	cve='CVE-2017-5715'
-	if ! is_cpu_vulnerable 2; then
+	if ! is_cpu_vulnerable "$cve"; then
 		# override status & msg in case CPU is not vulnerable after all
 		pvulnstatus $cve OK "your CPU vendor reported your CPU model as not vulnerable"
 	elif [ "$retpoline" = 1 ]; then
@@ -2951,8 +3491,8 @@ check_variant2_bsd()
 	fi
 }
 
-########################
-# MELTDOWN aka VARIANT 3
+##################
+# MELTDOWN SECTION
 
 # no security impact but give a hint to the user in verbose mode
 # about PCID/INVPCID cpuid features that must be present to avoid
@@ -2986,19 +3526,21 @@ pti_performance_check()
 	fi
 }
 
-check_variant3()
+# rogue data cache load aka 'Meltdown' aka 'Variant 3'
+check_CVE_2017_5754()
 {
-	_info "\033[1;34mCVE-2017-5754 [rogue data cache load] aka 'Meltdown' aka 'Variant 3'\033[0m"
+	cve='CVE-2017-5754'
+	_info "\033[1;34m$cve aka '$(cve2name "$cve")'\033[0m"
 	if [ "$os" = Linux ]; then
-		check_variant3_linux
+		check_CVE_2017_5754_linux
 	elif echo "$os" | grep -q BSD; then
-		check_variant3_bsd
+		check_CVE_2017_5754_bsd
 	else
 		_warn "Unsupported OS ($os)"
 	fi
 }
 
-check_variant3_linux()
+check_CVE_2017_5754_linux()
 {
 	status=UNK
 	sys_interface_available=0
@@ -3033,7 +3575,7 @@ check_variant3_linux()
 			# nopti option that is part of the patch (kernel command line option)
 			# 'kpti=': arm
 			kpti_can_tell=1
-			if ! which "${opt_arch_prefix}strings" >/dev/null 2>&1; then
+			if ! command -v "${opt_arch_prefix}strings" >/dev/null 2>&1; then
 				pstatus yellow UNKNOWN "missing '${opt_arch_prefix}strings' tool, please install it, usually it's in the binutils package"
 			else
 				kpti_support=$("${opt_arch_prefix}strings" "$kernel" | grep -w -e nopti -e kpti=)
@@ -3061,6 +3603,8 @@ check_variant3_linux()
 			dmesg_grep="Kernel/User page tables isolation: enabled"
 			dmesg_grep="$dmesg_grep|Kernel page table isolation enabled"
 			dmesg_grep="$dmesg_grep|x86/pti: Unmapping kernel while in userspace"
+			# aarch64
+			dmesg_grep="$dmesg_grep|CPU features: detected( feature)?: Kernel page table isolation \(KPTI\)"
 			if grep ^flags "$procfs/cpuinfo" | grep -qw pti; then
 				# vanilla PTI patch sets the 'pti' flag in cpuinfo
 				_debug "kpti_enabled: found 'pti' flag in $procfs/cpuinfo"
@@ -3073,6 +3617,10 @@ check_variant3_linux()
 				# Red Hat Backport creates a dedicated file, see https://access.redhat.com/articles/3311301
 				kpti_enabled=$(cat /sys/kernel/debug/x86/pti_enabled 2>/dev/null)
 				_debug "kpti_enabled: file /sys/kernel/debug/x86/pti_enabled exists and says: $kpti_enabled"
+			elif is_xen_dom0; then
+				pti_xen_pv_domU=$(xl dmesg | grep 'XPTI' | grep 'DomU enabled' | head -1)
+
+				[ -n "$pti_xen_pv_domU" ] && kpti_enabled=1
 			fi
 			if [ -z "$kpti_enabled" ]; then
 				dmesg_grep "$dmesg_grep"; ret=$?
@@ -3109,24 +3657,8 @@ check_variant3_linux()
 
 
 	# Test if the current host is a Xen PV Dom0 / DomU
-	if [ -d "/proc/xen" ]; then
-		# XXX do we have a better way that relying on dmesg?
-		dmesg_grep 'Booting paravirtualized kernel on Xen$'; ret=$?
-		if [ $ret -eq 2 ]; then
-			_warn "dmesg truncated, Xen detection will be unreliable. Please reboot and relaunch this script"
-		elif [ $ret -eq 0 ]; then
-			if [ -e /proc/xen/capabilities ] && grep -q "control_d" /proc/xen/capabilities; then
-				xen_pv_domo=1
-			else
-				xen_pv_domu=1
-			fi
-			# PVHVM guests also print 'Booting paravirtualized kernel', so we need this check.
-			dmesg_grep 'Xen HVM callback vector for event delivery is enabled$'; ret=$?
-			if [ $ret -eq 0 ]; then
-				xen_pv_domu=0
-			fi
-		fi
-	fi
+	is_xen_dom0 && xen_pv_domo=1
+	is_xen_domU && xen_pv_domu=1
 
 	if [ "$opt_live" = 1 ]; then
 		# checking whether we're running under Xen PV 64 bits. If yes, we are affected by variant3
@@ -3139,8 +3671,7 @@ check_variant3_linux()
 		fi
 	fi
 
-	cve='CVE-2017-5754'
-	if ! is_cpu_vulnerable 3; then
+	if ! is_cpu_vulnerable "$cve"; then
 		# override status & msg in case CPU is not vulnerable after all
 		pvulnstatus $cve OK "your CPU vendor reported your CPU model as not vulnerable"
 	elif [ -z "$msg" ]; then
@@ -3160,7 +3691,7 @@ check_variant3_linux()
 				if [ -n "$kpti_support" ]; then
 					if [ -e "/sys/kernel/debug/x86/pti_enabled" ]; then
 						explain "Your kernel supports PTI but it's disabled, you can enable it with \`echo 1 > /sys/kernel/debug/x86/pti_enabled\`"
-					elif grep -q -w nopti -w pti=off /proc/cmdline; then
+					elif grep -q -w -e nopti -e pti=off "$procfs/cmdline"; then
 						explain "Your kernel supports PTI but it has been disabled on command-line, remove the nopti or pti=off option from your bootloader configuration"
 					else
 						explain "Your kernel supports PTI but it has been disabled, check \`dmesg\` right after boot to find clues why the system disabled it"
@@ -3208,7 +3739,7 @@ check_variant3_linux()
 	fi
 }
 
-check_variant3_bsd()
+check_CVE_2017_5754_bsd()
 {
 	_info_nol "* Kernel supports Page Table Isolation (PTI): "
 	kpti_enabled=$(sysctl -n vm.pmap.pti 2>/dev/null)
@@ -3227,8 +3758,7 @@ check_variant3_bsd()
 
 	pti_performance_check
 
-	cve='CVE-2017-5754'
-	if ! is_cpu_vulnerable 3; then
+	if ! is_cpu_vulnerable "$cve"; then
 		# override status & msg in case CPU is not vulnerable after all
 		pvulnstatus $cve OK "your CPU vendor reported your CPU model as not vulnerable"
 	elif [ "$kpti_enabled" = 1 ]; then
@@ -3240,9 +3770,14 @@ check_variant3_bsd()
 	fi
 }
 
-check_variant3a()
+####################
+# VARIANT 3A SECTION
+
+# rogue system register read aka 'Variant 3a'
+check_CVE_2018_3640()
 {
-	_info "\033[1;34mCVE-2018-3640 [rogue system register read] aka 'Variant 3a'\033[0m"
+	cve='CVE-2018-3640'
+	_info "\033[1;34m$cve aka '$(cve2name "$cve")'\033[0m"
 
 	status=UNK
 	sys_interface_available=0
@@ -3257,8 +3792,7 @@ check_variant3a()
 		pstatus yellow NO
 	fi
 
-	cve='CVE-2018-3640'
-	if ! is_cpu_vulnerable 3a; then
+	if ! is_cpu_vulnerable "$cve"; then
 		# override status & msg in case CPU is not vulnerable after all
 		pvulnstatus $cve OK "your CPU vendor reported your CPU model as not vulnerable"
 	elif [ -n "$cpuid_ssbd" ]; then
@@ -3269,10 +3803,25 @@ check_variant3a()
 	fi
 }
 
-check_variant4()
-{
-	_info "\033[1;34mCVE-2018-3639 [speculative store bypass] aka 'Variant 4'\033[0m"
+###################
+# VARIANT 4 SECTION
 
+# speculative store bypass aka 'Variant 4'
+check_CVE_2018_3639()
+{
+	cve='CVE-2018-3639'
+	_info "\033[1;34m$cve aka '$(cve2name "$cve")'\033[0m"
+	if [ "$os" = Linux ]; then
+		check_CVE_2018_3639_linux
+	elif echo "$os" | grep -q BSD; then
+		check_CVE_2018_3639_bsd
+	else
+		_warn "Unsupported OS ($os)"
+	fi
+}
+
+check_CVE_2018_3639_linux()
+{
 	status=UNK
 	sys_interface_available=0
 	msg=''
@@ -3281,11 +3830,11 @@ check_variant4()
 		sys_interface_available=1
 	fi
 	if [ "$opt_sysfs_only" != 1 ]; then
-		_info_nol "* Kernel supports speculation store bypass: "
+		_info_nol "* Kernel supports disabling speculative store bypass (SSB): "
 		if [ "$opt_live" = 1 ]; then
-			if grep -Eq 'Speculation.?Store.?Bypass:' /proc/self/status 2>/dev/null; then
-				kernel_ssb='found in /proc/self/status'
-				_debug "found Speculation.Store.Bypass: in /proc/self/status"
+			if grep -Eq 'Speculation.?Store.?Bypass:' "$procfs/self/status" 2>/dev/null; then
+				kernel_ssb="found in $procfs/self/status"
+				_debug "found Speculation.Store.Bypass: in $procfs/self/status"
 			fi
 		fi
 		if [ -z "$kernel_ssb" ] && [ -n "$kernel" ]; then
@@ -3303,21 +3852,58 @@ check_variant4()
 			pstatus yellow NO
 		fi
 
+		kernel_ssbd_enabled=-1
+		if [ "$opt_live" = 1 ]; then
+			# https://elixir.bootlin.com/linux/v5.0/source/fs/proc/array.c#L340
+			_info_nol "* SSB mitigation is enabled and active: "
+			if grep -Eq 'Speculation.?Store.?Bypass:[[:space:]]+thread' "$procfs/self/status" 2>/dev/null; then
+				kernel_ssbd_enabled=1
+				pstatus green YES "per-thread through prctl"
+			elif grep -Eq 'Speculation.?Store.?Bypass:[[:space:]]+globally mitigated' "$procfs/self/status" 2>/dev/null; then
+				kernel_ssbd_enabled=2
+				pstatus green YES "global"
+			elif grep -Eq 'Speculation.?Store.?Bypass:[[:space:]]+vulnerable' "$procfs/self/status" 2>/dev/null; then
+				kernel_ssbd_enabled=0
+				pstatus yellow NO
+			elif grep -Eq 'Speculation.?Store.?Bypass:[[:space:]]+not vulnerable' "$procfs/self/status" 2>/dev/null; then
+				kernel_ssbd_enabled=-2
+				pstatus blue NO "not vulnerable"
+			fi
+
+			if [ "$kernel_ssbd_enabled" = 1 ]; then
+				_info_nol "* SSB mitigation currently active for selected processes: "
+				mitigated_processes=$(grep -El 'Speculation.?Store.?Bypass:[[:space:]]+thread (force )?mitigated' /proc/*/status \
+					| sed s/status/exe/ | xargs -r -n1 readlink -f | xargs -r -n1 basename | sort -u | tr "\n" " " | sed 's/ $//')
+				if [ -n "$mitigated_processes" ]; then
+					pstatus green YES "$mitigated_processes"
+				else
+					pstatus yellow NO "no process found using SSB mitigation through prctl"
+				fi
+			fi
+		fi
+
 	elif [ "$sys_interface_available" = 0 ]; then
 		# we have no sysfs but were asked to use it only!
 		msg="/sys vulnerability interface use forced, but it's not available!"
 		status=UNK
 	fi
 
-	cve='CVE-2018-3639'
-	if ! is_cpu_vulnerable 4; then
+	if ! is_cpu_vulnerable "$cve"; then
 		# override status & msg in case CPU is not vulnerable after all
 		pvulnstatus $cve OK "your CPU vendor reported your CPU model as not vulnerable"
 	elif [ -z "$msg" ] || [ "$msg" = "Vulnerable" ]; then
 		# if msg is empty, sysfs check didn't fill it, rely on our own test
 		if [ -n "$cpuid_ssbd" ]; then
 			if [ -n "$kernel_ssb" ]; then
-				pvulnstatus $cve OK "your system provides the necessary tools for software mitigation"
+				if [ "$opt_live" = 1 ]; then
+					if [ "$kernel_ssbd_enabled" -gt 0 ]; then
+						pvulnstatus $cve OK "your CPU and kernel both support SSBD and mitigation is enabled"
+					else
+						pvulnstatus $cve VULN "your CPU and kernel both support SSBD but the mitigation is not active"
+					fi
+				else
+					pvulnstatus $cve OK "your system provides the necessary tools for software mitigation"
+				fi
 			else
 				pvulnstatus $cve VULN "your kernel needs to be updated"
 				explain "You have a recent-enough CPU microcode but your kernel is too old to use the new features exported by your CPU's microcode. If you're using a distro kernel, upgrade your distro to get the latest kernel available. Otherwise, recompile the kernel from recent-enough sources."
@@ -3336,10 +3922,103 @@ check_variant4()
 	fi
 }
 
-check_variantl1tf()
+check_CVE_2018_3639_bsd()
 {
-	_info "\033[1;34mCVE-2018-3615/3620/3646 [L1 terminal fault] aka 'Foreshadow & Foreshadow-NG'\033[0m"
+	_info_nol "* Kernel supports speculation store bypass: "
+	if sysctl hw.spec_store_bypass_disable >/dev/null 2>&1; then
+		kernel_ssb=1
+		pstatus green YES
+	else
+		kernel_ssb=0
+		pstatus yellow NO
+	fi
 
+	_info_nol "* Speculation store bypass is administratively enabled: "
+	ssb_enabled=$(sysctl -n hw.spec_store_bypass_disable 2>/dev/null)
+	_debug "hw.spec_store_bypass_disable=$ssb_enabled"
+	case "$ssb_enabled" in
+		0) pstatus yellow NO "disabled";;
+		1) pstatus green YES "enabled";;
+		2) pstatus green YES "auto mode";;
+		*) pstatus yellow NO "unavailable";;
+	esac
+
+	_info_nol "* Speculation store bypass is currently active: "
+	ssb_active=$(sysctl -n hw.spec_store_bypass_disable_active 2>/dev/null)
+	_debug "hw.spec_store_bypass_disable_active=$ssb_active"
+	case "$ssb_active" in
+		1) pstatus green YES;;
+		*) pstatus yellow NO;;
+	esac
+
+	if ! is_cpu_vulnerable "$cve"; then
+		pvulnstatus $cve OK "your CPU vendor reported your CPU model as not vulnerable"
+	else
+		if [ "$ssb_active" = 1 ]; then
+				pvulnstatus $cve OK "SSBD mitigates the vulnerability"
+		elif [ -n "$cpuid_ssbd" ]; then
+			if [ "$kernel_ssb" = 1 ]; then
+				pvulnstatus $cve VULN "you need to enable ssbd through sysctl to mitigate the vulnerability"
+			else
+				pvulnstatus $cve VULN "your kernel needs to be updated"
+			fi
+		else
+			if [ "$kernel_ssb" = 1 ]; then
+				pvulnstatus $cve VULN "Your CPU doesn't support SSBD"
+			else
+				pvulnstatus $cve VULN "Neither your CPU nor your kernel support SSBD"
+			fi
+		fi
+	fi
+}
+
+###########################
+# L1TF / FORESHADOW SECTION
+
+# L1 terminal fault (SGX) aka 'Foreshadow'
+check_CVE_2018_3615()
+{
+	cve='CVE-2018-3615'
+	_info "\033[1;34m$cve aka '$(cve2name "$cve")'\033[0m"
+
+	_info_nol "* CPU microcode mitigates the vulnerability: "
+	if [ "$cpu_flush_cmd" = 1 ] && [ "$cpuid_sgx" = 1 ]; then
+		# no easy way to detect a fixed SGX but we know that
+		# microcodes that have the FLUSH_CMD MSR also have the
+		# fixed SGX (for CPUs that support it)
+		pstatus green YES
+	elif [ "$cpuid_sgx" = 1 ]; then
+		pstatus red NO
+	else
+		pstatus blue N/A
+	fi
+
+	if ! is_cpu_vulnerable "$cve"; then
+		# override status & msg in case CPU is not vulnerable after all
+		pvulnstatus $cve OK "your CPU vendor reported your CPU model as not vulnerable"
+	elif [ "$cpu_flush_cmd" = 1 ]; then
+		pvulnstatus $cve OK "your CPU microcode mitigates the vulnerability"
+	else
+		pvulnstatus $cve VULN "your CPU supports SGX and the microcode is not up to date"
+	fi
+}
+
+# L1 terminal fault (OS) aka 'Foreshadow-NG (OS)'
+check_CVE_2018_3620()
+{
+	cve='CVE-2018-3620'
+	_info "\033[1;34m$cve aka '$(cve2name "$cve")'\033[0m"
+	if [ "$os" = Linux ]; then
+		check_CVE_2018_3620_linux
+	elif echo "$os" | grep -q BSD; then
+		check_CVE_2018_3620_bsd
+	else
+		_warn "Unsupported OS ($os)"
+	fi
+}
+
+check_CVE_2018_3620_linux()
+{
 	status=UNK
 	sys_interface_available=0
 	msg=''
@@ -3348,21 +4027,607 @@ check_variantl1tf()
 		sys_interface_available=1
 	fi
 	if [ "$opt_sysfs_only" != 1 ]; then
-		:
+		_info_nol "* Kernel supports PTE inversion: "
+		if ! command -v "${opt_arch_prefix}strings" >/dev/null 2>&1; then
+			pteinv_supported=-1
+		else
+			if "${opt_arch_prefix}strings" "$kernel" | grep -Fq 'PTE Inversion'; then
+				pstatus green YES "found in kernel image"
+				_debug "pteinv: found pte inversion evidence in kernel image"
+				pteinv_supported=1
+			else
+				pstatus yellow NO
+				pteinv_supported=0
+			fi
+		fi
+
+		_info_nol "* PTE inversion enabled and active: "
+		if [ "$opt_live" = 1 ]; then
+			if [ -n "$fullmsg" ]; then
+				if echo "$fullmsg" | grep -q 'Mitigation: PTE Inversion'; then
+					pstatus green YES
+					pteinv_active=1
+				else
+					pstatus yellow NO
+					pteinv_active=0
+				fi
+			else
+				pstatus yellow UNKNOWN "sysfs interface not available"
+				pteinv_active=-1
+			fi
+		else
+			pstatus blue N/A "not testable in offline mode"
+		fi
 	elif [ "$sys_interface_available" = 0 ]; then
 		# we have no sysfs but were asked to use it only!
 		msg="/sys vulnerability interface use forced, but it's not available!"
 		status=UNK
 	fi
 
-	cve='CVE-2018-3615/3620/3646'
-	if ! is_cpu_vulnerable l1tf; then
+	if ! is_cpu_vulnerable "$cve"; then
 		# override status & msg in case CPU is not vulnerable after all
 		pvulnstatus $cve OK "your CPU vendor reported your CPU model as not vulnerable"
 	elif [ -z "$msg" ]; then
-		pvulnstatus $cve VULN "your CPU is known to be vulnerable, and your kernel doesn't report that it mitigates the issue, but more thorough mitigation checking by this script is being worked on (check often for new versions!)"
+		# if msg is empty, sysfs check didn't fill it, rely on our own test
+		if [ "$pteinv_supported" = 1 ]; then
+			if [ "$pteinv_active" = 1 ] || [ "$opt_live" != 1 ]; then
+				pvulnstatus $cve OK "PTE inversion mitigates the vunerability"
+			else
+				pvulnstatus $cve VULN "Your kernel supports PTE inversion but it doesn't seem to be enabled"
+			fi
+		else
+			pvulnstatus $cve VULN "Your kernel doesn't support PTE inversion, update it"
+		fi
 	else
 		pvulnstatus $cve "$status" "$msg"
+	fi
+}
+
+check_CVE_2018_3620_bsd()
+{
+	_info_nol "* Kernel reserved the memory page at physical address 0x0: "
+	if ! kldstat -q -m vmm; then
+		kldload vmm 2>/dev/null && kldload_vmm=1
+		_debug "attempted to load module vmm, kldload_vmm=$kldload_vmm"
+	else
+		_debug "vmm module already loaded"
+	fi
+	if sysctl hw.vmm.vmx.l1d_flush >/dev/null 2>&1; then
+		# https://security.FreeBSD.org/patches/SA-18:09/l1tf-11.2.patch
+		# this is very difficult to detect that the kernel reserved the 0 page, but this fix
+		# is part of the exact same patch than the other L1TF CVE, so we detect it
+		# and deem it as OK if the other patch is there
+		pstatus green YES
+		bsd_zero_reserved=1
+	else
+		pstatus yellow NO
+		bsd_zero_reserved=0
+	fi
+
+	if ! is_cpu_vulnerable "$cve"; then
+		pvulnstatus $cve OK "your CPU vendor reported your CPU model as not vulnerable"
+	else
+		if [ "$bsd_zero_reserved" = 1 ]; then
+			pvulnstatus $cve OK "kernel mitigates the vulnerability"
+		else
+			pvulnstatus $cve VULN "your kernel needs to be updated"
+		fi
+	fi
+}
+
+# L1TF VMM
+check_CVE_2018_3646()
+{
+	cve='CVE-2018-3646'
+	_info "\033[1;34m$cve aka '$(cve2name "$cve")'\033[0m"
+	if [ "$os" = Linux ]; then
+		check_CVE_2018_3646_linux
+	elif echo "$os" | grep -q BSD; then
+		check_CVE_2018_3646_bsd
+	else
+		_warn "Unsupported OS ($os)"
+	fi
+}
+
+check_CVE_2018_3646_linux()
+{
+	status=UNK
+	sys_interface_available=0
+	msg=''
+	if sys_interface_check "/sys/devices/system/cpu/vulnerabilities/l1tf" '.*' quiet; then
+		# this kernel has the /sys interface, trust it over everything
+		sys_interface_available=1
+	fi
+	l1d_mode=-1
+	if [ "$opt_sysfs_only" != 1 ]; then
+		_info_nol "* This system is a host running a hypervisor: "
+		has_vmm=$opt_vmm
+		if [ "$has_vmm" = -1 ] && [ "$opt_paranoid" = 1 ]; then
+			# In paranoid mode, if --vmm was not specified on the command-line,
+			# we want to be secure before everything else, so assume we're running
+			# a hypervisor, as this requires more mitigations
+			has_vmm=2
+		elif [ "$has_vmm" = -1 ]; then
+			# Here, we want to know if we are hosting a hypervisor, and running some VMs on it.
+			# If we find no evidence that this is the case, assume we're not (to avoid scaring users),
+			# this can always be overridden with --vmm in any case.
+			has_vmm=0
+			if command -v pgrep >/dev/null 2>&1; then
+				# remove xenbus and xenwatch, also present inside domU
+				# remove libvirtd as it can also be used to manage containers and not VMs
+				if pgrep qemu >/dev/null || pgrep kvm >/dev/null || \
+					pgrep xenstored >/dev/null || pgrep xenconsoled >/dev/null; then
+					has_vmm=1
+				fi
+			else
+				# ignore SC2009 as `ps ax` is actually used as a fallback if `pgrep` isn't installed
+				# shellcheck disable=SC2009
+				if ps ax | grep -vw grep | grep -q -e '\<qemu' -e '/qemu' -e '<\kvm' -e '/kvm' -e '/xenstored' -e '/xenconsoled'; then
+					has_vmm=1
+				fi
+			fi
+		fi
+		if [ "$has_vmm" = 0 ]; then
+			if [ "$opt_vmm" != -1 ]; then
+				pstatus green NO "forced from command line"
+			else
+				pstatus green NO
+			fi
+		else
+			if [ "$opt_vmm" != -1 ]; then
+				pstatus blue YES "forced from command line"
+			elif [ "$has_vmm" = 2 ]; then
+				pstatus blue YES "paranoid mode"
+			else
+				pstatus blue YES
+			fi
+		fi
+
+		_info "* Mitigation 1 (KVM)"
+		_info_nol "  * EPT is disabled: "
+		if [ "$opt_live" = 1 ]; then
+			if ! [ -r /sys/module/kvm_intel/parameters/ept ]; then
+				pstatus blue N/A "the kvm_intel module is not loaded"
+			elif [ "$(cat /sys/module/kvm_intel/parameters/ept)" = N ]; then
+				pstatus green YES
+				ept_disabled=1
+			else
+				pstatus yellow NO
+			fi
+		else
+			pstatus blue N/A "not testable in offline mode"
+		fi
+
+		_info "* Mitigation 2"
+		_info_nol "  * L1D flush is supported by kernel: "
+		if [ "$opt_live" = 1 ] && grep -qw flush_l1d "$procfs/cpuinfo"; then
+			l1d_kernel="found flush_l1d in $procfs/cpuinfo"
+		fi
+		if [ -z "$l1d_kernel" ]; then
+			if ! command -v "${opt_arch_prefix}strings" >/dev/null 2>&1; then
+				l1d_kernel_err="missing '${opt_arch_prefix}strings' tool, please install it, usually it's in the binutils package"
+			elif [ -n "$kernel_err" ]; then
+				l1d_kernel_err="$kernel_err"
+			elif "${opt_arch_prefix}strings" "$kernel" | grep -qw flush_l1d; then
+				l1d_kernel='found flush_l1d in kernel image'
+			fi
+		fi
+
+		if [ -n "$l1d_kernel" ]; then
+			pstatus green YES "$l1d_kernel"
+		elif [ -n "$l1d_kernel_err" ]; then
+			pstatus yellow UNKNOWN "$l1d_kernel_err"
+		else
+			pstatus yellow NO
+		fi
+
+		_info_nol "  * L1D flush enabled: "
+		if [ "$opt_live" = 1 ]; then
+			if [ -n "$fullmsg" ]; then
+				# vanilla: VMX: $l1dstatus, SMT $smtstatus
+				# Red Hat: VMX: SMT $smtstatus, L1D $l1dstatus
+				# $l1dstatus is one of (auto|vulnerable|conditional cache flushes|cache flushes|EPT disabled|flush not necessary)
+				# $smtstatus is one of (vulnerable|disabled)
+				# can also just be "Not affected"
+				if echo "$fullmsg" | grep -Eq -e 'Not affected' -e '(VMX:|L1D) (EPT disabled|vulnerable|flush not necessary)'; then
+					l1d_mode=0
+					pstatus yellow NO
+				elif echo "$fullmsg" | grep -Eq '(VMX:|L1D) conditional cache flushes'; then
+					l1d_mode=1
+					pstatus green YES "conditional flushes"
+				elif echo "$fullmsg" | grep -Eq '(VMX:|L1D) cache flushes'; then
+					l1d_mode=2
+					pstatus green YES "unconditional flushes"
+				else
+					if is_xen_dom0; then
+						l1d_xen_hardware=$(xl dmesg | grep 'Hardware features:' | grep 'L1D_FLUSH' | head -1)
+						l1d_xen_hypervisor=$(xl dmesg | grep 'Xen settings:' | grep 'L1D_FLUSH' | head -1)
+						l1d_xen_pv_domU=$(xl dmesg | grep 'PV L1TF shadowing:' | grep 'DomU enabled' | head -1)
+
+						if [ -n "$l1d_xen_hardware" ] && [ -n "$l1d_xen_hypervisor" ] && [ -n "$l1d_xen_pv_domU" ]; then
+							l1d_mode=5
+							pstatus green YES "for XEN guests"
+						elif [ -n "$l1d_xen_hardware" ] && [ -n "$l1d_xen_hypervisor" ]; then
+							l1d_mode=4
+							pstatus yellow YES "for XEN guests (HVM only)"
+						elif [ -n "$l1d_xen_pv_domU" ]; then
+							l1d_mode=3
+							pstatus yellow YES "for XEN guests (PV only)"
+						else
+							l1d_mode=0
+							pstatus yellow NO "for XEN guests"
+						fi
+					else
+						l1d_mode=-1
+						pstatus yellow UNKNOWN "unrecognized mode"
+					fi
+				fi
+			else
+				l1d_mode=-1
+				pstatus yellow UNKNOWN "can't find or read /sys/devices/system/cpu/vulnerabilities/l1tf"
+			fi
+		else
+			l1d_mode=-1
+			pstatus blue N/A "not testable in offline mode"
+		fi
+
+		_info_nol "  * Hardware-backed L1D flush supported: "
+		if [ "$opt_live" = 1 ]; then
+			if grep -qw flush_l1d "$procfs/cpuinfo" || [ -n "$l1d_xen_hardware" ]; then
+				pstatus green YES "performance impact of the mitigation will be greatly reduced"
+			else
+				pstatus blue NO "flush will be done in software, this is slower"
+			fi
+		else
+			pstatus blue N/A "not testable in offline mode"
+		fi
+
+		_info_nol "  * Hyper-Threading (SMT) is enabled: "
+		is_cpu_smt_enabled; smt_enabled=$?
+		if [ "$smt_enabled" = 0 ]; then
+			pstatus yellow YES
+		elif [ "$smt_enabled" = 1 ]; then
+			pstatus green NO
+		else
+			pstatus yellow UNKNOWN
+		fi
+
+	elif [ "$sys_interface_available" = 0 ]; then
+		# we have no sysfs but were asked to use it only!
+		msg="/sys vulnerability interface use forced, but it's not available!"
+		status=UNK
+		l1d_mode=-1
+	fi
+
+	if ! is_cpu_vulnerable "$cve"; then
+		# override status & msg in case CPU is not vulnerable after all
+		pvulnstatus $cve OK "your CPU vendor reported your CPU model as not vulnerable"
+	elif [ "$fullmsg" = "Not affected" ]; then
+		# just in case a very recent kernel knows better than we do
+		pvulnstatus $cve OK "your kernel reported your CPU model as not vulnerable"
+	elif [ "$has_vmm" = 0 ]; then
+		pvulnstatus $cve OK "this system is not running a hypervisor"
+	else
+		if [ "$ept_disabled" = 1 ]; then
+			pvulnstatus $cve OK "EPT is disabled which mitigates the vulnerability"
+		elif [ "$opt_paranoid" = 0 ]; then
+			if [ "$l1d_mode" -ge 1 ]; then
+				pvulnstatus $cve OK "L1D flushing is enabled and mitigates the vulnerability"
+			else
+				pvulnstatus $cve VULN "disable EPT or enable L1D flushing to mitigate the vulnerability"
+			fi
+		else
+			if [ "$l1d_mode" -ge 2 ]; then
+				if [ "$smt_enabled" = 1 ]; then
+					pvulnstatus $cve OK "L1D unconditional flushing and Hyper-Threading disabled are mitigating the vulnerability"
+				else
+					pvulnstatus $cve VULN "Hyper-Threading must be disabled to fully mitigate the vulnerability"
+				fi
+			else
+				if [ "$smt_enabled" = 1 ]; then
+					pvulnstatus $cve VULN "L1D unconditional flushing should be enabled to fully mitigate the vulnerability"
+				else
+					pvulnstatus $cve VULN "enable L1D unconditional flushing and disable Hyper-Threading to fully mitigate the vulnerability"
+				fi
+			fi
+		fi
+
+		if [ $l1d_mode -gt 3 ]; then
+			_warn
+			_warn "This host is a Xen Dom0. Please make sure that you are running your DomUs"
+			_warn "with a kernel which contains CVE-2018-3646 mitigations."
+			_warn
+			_warn "See https://www.suse.com/support/kb/doc/?id=7023078 and XSA-273 for details."
+		fi
+	fi
+}
+
+check_CVE_2018_3646_bsd()
+{
+	_info_nol "* Kernel supports L1D flushing: "
+	if sysctl hw.vmm.vmx.l1d_flush >/dev/null 2>&1; then
+		pstatus green YES
+		kernel_l1d_supported=1
+	else
+		pstatus yellow NO
+		kernel_l1d_supported=0
+	fi
+
+	_info_nol "* L1D flushing is enabled: "
+	kernel_l1d_enabled=$(sysctl -n hw.vmm.vmx.l1d_flush 2>/dev/null)
+	case "$kernel_l1d_enabled" in
+		0) pstatus yellow NO;;
+		1) pstatus green YES;;
+		"") pstatus yellow NO;;
+		*) pstatus yellow UNKNOWN;;
+	esac
+
+	if ! is_cpu_vulnerable "$cve"; then
+		pvulnstatus $cve OK "your CPU vendor reported your CPU model as not vulnerable"
+	else
+		if [ "$kernel_l1d_enabled" = 1 ]; then
+			pvulnstatus $cve OK "L1D flushing mitigates the vulnerability"
+		elif [ "$kernel_l1d_supported" = 1 ]; then
+			pvulnstatus $cve VULN "L1D flushing is supported by your kernel but is disabled"
+		else
+			pvulnstatus $cve VULN "your kernel needs to be updated"
+		fi
+	fi
+}
+
+###################
+# MSBDS SECTION
+
+# Microarchitectural Store Buffer Data Sampling
+check_CVE_2018_12126()
+{
+	cve='CVE-2018-12126'
+	check_mds $cve
+}
+
+###################
+# MFBDS SECTION
+
+# Microarchitectural Fill Buffer Data Sampling
+check_CVE_2018_12130()
+{
+	cve='CVE-2018-12130'
+	check_mds $cve
+}
+
+###################
+# MLPDS SECTION
+
+# Microarchitectural Load Port Data Sampling
+check_CVE_2018_12127()
+{
+	cve='CVE-2018-12127'
+	check_mds $cve
+}
+
+###################
+# MDSUM SECTION
+
+# Microarchitectural Data Sampling Uncacheable Memory 
+check_CVE_2019_11091()
+{
+	cve='CVE-2019-11091'
+	check_mds $cve
+}
+
+# Microarchitectural Data Sampling
+check_mds()
+{
+	cve=$1
+	_info "\033[1;34m$cve aka '$(cve2name "$cve")'\033[0m"
+	if [ "$os" = Linux ]; then
+		check_mds_linux "$cve"
+	elif echo "$os" | grep -q BSD; then
+		check_mds_bsd "$cve"
+	else
+		_warn "Unsupported OS ($os)"
+	fi
+}
+
+check_mds_bsd()
+{
+	_info_nol "* Kernel supports using MD_CLEAR mitigation: "
+	if [ "$opt_live" = 1 ]; then
+		if sysctl hw.mds_disable >/dev/null 2>&1; then
+			pstatus green YES
+			kernel_md_clear=1
+		else
+			pstatus yellow NO
+			kernel_md_clear=0
+		fi
+	else
+		if command -v "strings" >/dev/null 2>&1; then
+			if strings /boot/kernel/kernel | grep -Fq hw.mds_disable; then
+				pstatus green YES
+				kernel_md_clear=1
+			else
+				kernel_md_clear=0
+				pstatus yellow NO
+			fi
+		else
+			pstatus yellow UNKNOWN
+		fi
+	fi
+
+	_info_nol "* CPU Hyper-Threading (SMT) is disabled: "
+	if sysctl machdep.hyperthreading_allowed >/dev/null 2>&1; then
+		kernel_smt_allowed=$(sysctl -n machdep.hyperthreading_allowed 2>/dev/null)
+		if [ "$kernel_smt_allowed" = 1 ]; then
+			pstatus yellow NO
+		else
+			pstatus green YES
+		fi
+	else
+		pstatus yellow UNKNOWN "sysctl machdep.hyperthreading_allowed doesn't exist"
+	fi
+
+	_info_nol "* Kernel mitigation is enabled: "
+	if [ "$kernel_md_clear" = 1 ]; then
+		kernel_mds_enabled=$(sysctl -n hw.mds_disable 2>/dev/null)
+	else
+		kernel_mds_enabled=0
+	fi
+	case "$kernel_mds_enabled" in
+		0) pstatus yellow NO;;
+		1) pstatus green YES "with microcode support";;
+		2) pstatus green YES "software-only support (SLOW)";;
+		3) pstatus green YES;;
+		*) pstatus yellow UNKNOWN "unknown value $kernel_mds_enabled"
+	esac
+
+	_info_nol "* Kernel mitigation is active: "
+	if [ "$kernel_md_clear" = 1 ]; then
+		kernel_mds_state=$(sysctl -n hw.mds_disable_state 2>/dev/null)
+	else
+		kernel_mds_state=inactive
+	fi
+	# https://github.com/freebsd/freebsd/blob/master/sys/x86/x86/cpu_machdep.c#L953
+	case "$kernel_mds_state" in
+		inactive)  pstatus yellow NO;;
+		VERW)      pstatus green YES "with microcode support";;
+		software*) pstatus green YES "software-only support (SLOW)";;
+		*)         pstatus yellow UNKNOWN
+	esac
+
+	if ! is_cpu_vulnerable "$cve"; then
+		pvulnstatus "$cve" OK "your CPU vendor reported your CPU model as not vulnerable"
+	else
+		if [ "$cpuid_md_clear" = 1 ]; then
+			if [ "$kernel_md_clear" = 1 ]; then
+				if [ "$opt_live" = 1 ]; then
+					# mitigation must also be enabled
+					if [ "$kernel_mds_enabled" -ge 1 ]; then
+						if [ "$opt_paranoid" != 1 ] || [ "$kernel_smt_allowed" = 0 ]; then
+							pvulnstatus "$cve" OK "Your microcode and kernel are both up to date for this mitigation, and mitigation is enabled"
+						else
+							pvulnstatus "$cve" VULN "Your microcode and kernel are both up to date for this mitigation, but your must disable SMT (Hyper-Threading) for a complete mitigation"
+						fi
+					else
+						pvulnstatus "$cve" VULN "Your microcode and kernel are both up to date for this mitigation, but the mitigation is not active"
+					fi
+				else
+					pvulnstatus "$cve" OK "Your microcode and kernel are both up to date for this mitigation"
+				fi
+			else
+				pvulnstatus "$cve" VULN "Your microcode supports mitigation, but your kernel doesn't, upgrade it to mitigate the vulnerability"
+			fi
+		else
+			if [ "$kernel_md_clear" = 1 ]; then
+				pvulnstatus "$cve" VULN "Your kernel supports mitigation, but your CPU microcode also needs to be updated to mitigate the vulnerability"
+			else
+				pvulnstatus "$cve" VULN "Neither your kernel or your microcode support mitigation, upgrade both to mitigate the vulnerability"
+			fi
+		fi
+	fi
+}
+
+check_mds_linux()
+{
+	status=UNK
+	sys_interface_available=0
+	msg=''
+	if sys_interface_check "/sys/devices/system/cpu/vulnerabilities/mds" '^[^;]+'; then
+		# this kernel has the /sys interface, trust it over everything
+		sys_interface_available=1
+	fi
+	if [ "$opt_sysfs_only" != 1 ]; then
+		_info_nol "* Kernel supports using MD_CLEAR mitigation: "
+		kernel_md_clear=''
+		kernel_md_clear_can_tell=1
+		if [ "$opt_live" = 1 ] && grep ^flags $procfs/cpuinfo | grep -qw md_clear; then
+			kernel_md_clear="md_clear found in $procfs/cpuinfo"
+			pstatus green YES "$kernel_md_clear"
+		fi
+		if [ -z "$kernel_md_clear" ]; then
+			if ! command -v "${opt_arch_prefix}strings" >/dev/null 2>&1; then
+				kernel_md_clear_can_tell=0
+			elif [ -n "$kernel_err" ]; then
+				kernel_md_clear_can_tell=0
+			elif "${opt_arch_prefix}strings" "$kernel" | grep -q 'Clear CPU buffers'; then
+				_debug "md_clear: found 'Clear CPU buffers' string in kernel image"
+				kernel_md_clear='found md_clear implementation evidence in kernel image'
+				pstatus green YES "$kernel_md_clear"
+			fi
+		fi
+		if [ -z "$kernel_md_clear" ]; then
+			if [ "$kernel_md_clear_can_tell" = 1 ]; then
+				pstatus yellow NO
+			else
+				pstatus yellow UNKNOWN
+			fi
+		fi
+
+		if [ "$opt_live" = 1 ] && [ "$sys_interface_available" = 1 ]; then
+			_info_nol "* Kernel mitigation is enabled and active: "
+			if echo "$fullmsg" | grep -qi ^mitigation; then
+				mds_mitigated=1
+				pstatus green YES
+			else
+				mds_mitigated=0
+				pstatus yellow NO
+			fi
+			_info_nol "* SMT is either mitigated or disabled: "
+			if echo "$fullmsg" | grep -Eq 'SMT (disabled|mitigated)'; then
+				mds_smt_mitigated=1
+				pstatus green YES
+			else
+				mds_smt_mitigated=0
+				pstatus yellow NO
+			fi
+		fi
+	elif [ "$sys_interface_available" = 0 ]; then
+		# we have no sysfs but were asked to use it only!
+		msg="/sys vulnerability interface use forced, but it's not available!"
+		status=UNK
+	fi
+
+	if ! is_cpu_vulnerable "$cve"; then
+		# override status & msg in case CPU is not vulnerable after all
+		pvulnstatus "$cve" OK "your CPU vendor reported your CPU model as not vulnerable"
+	elif [ -z "$msg" ]; then
+		# if msg is empty, sysfs check didn't fill it, rely on our own test
+		if [ "$cpuid_md_clear" = 1 ]; then
+			if [ -n "$kernel_md_clear" ]; then
+				if [ "$opt_live" = 1 ]; then
+					# mitigation must also be enabled
+					if [ "$mds_mitigated" = 1 ]; then
+						if [ "$opt_paranoid" != 1 ] || [ "$mds_smt_mitigated" = 1 ]; then
+							pvulnstatus "$cve" OK "Your microcode and kernel are both up to date for this mitigation, and mitigation is enabled"
+						else
+							pvulnstatus "$cve" VULN "Your microcode and kernel are both up to date for this mitigation, but your must disable SMT (Hyper-Threading) for a complete mitigation"
+						fi
+					else
+						pvulnstatus "$cve" VULN "Your microcode and kernel are both up to date for this mitigation, but the mitigation is not active"
+					fi
+				else
+					pvulnstatus "$cve" OK "Your microcode and kernel are both up to date for this mitigation"
+				fi
+			else
+				pvulnstatus "$cve" VULN "Your microcode supports mitigation, but your kernel doesn't, upgrade it to mitigate the vulnerability"
+			fi
+		else
+			if [ -n "$kernel_md_clear" ]; then
+				pvulnstatus "$cve" VULN "Your kernel supports mitigation, but your CPU microcode also needs to be updated to mitigate the vulnerability"
+			else
+				pvulnstatus "$cve" VULN "Neither your kernel or your microcode support mitigation, upgrade both to mitigate the vulnerability"
+			fi
+		fi
+	else
+		if [ "$opt_paranoid" = 1 ]; then
+			# in paranoid mode, we don't only need microcode + kernel update, we also want SMT mitigation
+			if echo "$fullmsg" | grep -qF -e 'SMT mitigated' -e 'SMT disabled'; then
+				pvulnstatus "$cve" OK "$fullmsg"
+			else
+				pvulnstatus "$cve" VULN "Your kernel and microcode partially mitigate the vulnerability, but you must disable SMT (Hyper-Threading) for a complete mitigation"
+			fi
+		else
+			pvulnstatus "$cve" "$status" "$fullmsg"
+		fi
 	fi
 }
 
@@ -3373,33 +4638,44 @@ if [ "$opt_no_hw" = 0 ] && [ -z "$opt_arch_prefix" ]; then
 fi
 
 # now run the checks the user asked for
-if [ "$opt_variant1" = 1 ] || [ "$opt_allvariants" = 1 ]; then
-	check_variant1
-	_info
-fi
-if [ "$opt_variant2" = 1 ] || [ "$opt_allvariants" = 1 ]; then
-	check_variant2
-	_info
-fi
-if [ "$opt_variant3" = 1 ] || [ "$opt_allvariants" = 1 ]; then
-	check_variant3
-	_info
-fi
-if [ "$opt_variant3a" = 1 ] || [ "$opt_allvariants" = 1 ]; then
-	check_variant3a
-	_info
-fi
-if [ "$opt_variant4" = 1 ] || [ "$opt_allvariants" = 1 ]; then
-	check_variant4
-	_info
-fi
-if [ "$opt_variantl1tf" = 1 ] || [ "$opt_allvariants" = 1 ]; then
-	check_variantl1tf
-	_info
+for cve in $supported_cve_list
+do
+	if [ "$opt_cve_all" = 1 ] || echo "$opt_cve_list" | grep -qw "$cve"; then
+		check_"$(echo "$cve" | tr - _)"
+		_info
+	fi
+done
+
+if [ -n "$final_summary" ]; then
+	_info "> \033[46m\033[30mSUMMARY:\033[0m$final_summary"
+	_info ""
 fi
 
-_vars=$(set | grep -Ev '^[A-Z_[:space:]]' | sort | tr "\n" '|')
+if [ "$bad_accuracy" = 1 ]; then
+	_warn "We're missing some kernel info (see -v), accuracy might be reduced"
+fi
+
+_vars=$(set | grep -Ev '^[A-Z_[:space:]]' | grep -v -F 'mockme=' | sort | tr "\n" '|')
 _debug "variables at end of script: $_vars"
+
+if [ -n "$mockme" ] && [ "$opt_mock" = 1 ]; then
+	if command -v "gzip" >/dev/null 2>&1; then
+		# not a useless use of cat: gzipping cpuinfo directly doesn't work well
+		# shellcheck disable=SC2002
+		if command -v "base64" >/dev/null 2>&1; then
+			mock_cpuinfo="$(cat /proc/cpuinfo | gzip -c | base64 -w0)"
+		elif command -v "uuencode" >/dev/null 2>&1; then
+			mock_cpuinfo="$(cat /proc/cpuinfo | gzip -c | uuencode -m - | grep -Fv 'begin-base64' | grep -Fxv -- '====' | tr -d "\n")"
+		fi
+	fi
+	if [ -n "$mock_cpuinfo" ]; then
+		mockme=$(printf "%b\n%b" "$mockme" "SMC_MOCK_CPUINFO='$mock_cpuinfo'")
+		unset mock_cpuinfo
+	fi
+	_info ""
+	# shellcheck disable=SC2046
+	_warn "To mock this CPU, set those vars: "$(echo "$mockme" | sort -u)
+fi
 
 if [ "$opt_explain" = 0 ]; then
 	_info "Need more detailed information about mitigation options? Use --explain"
@@ -3407,12 +4683,22 @@ fi
 
 _info "A false sense of security is worse than no security at all, see --disclaimer"
 
+if [ "$mocked" = 1 ]; then
+	_info ""
+	_warn "One or several values have been mocked. This should only be done when debugging/testing this script."
+	_warn "The results do NOT reflect the actual status of the system we're running on."
+fi
+
 if [ "$opt_batch" = 1 ] && [ "$opt_batch_format" = "nrpe" ]; then
-	if [ ! -z "$nrpe_vuln" ]; then
+	if [ -n "$nrpe_vuln" ]; then
 		echo "Vulnerable:$nrpe_vuln"
 	else
 		echo "OK"
 	fi
+fi
+
+if [ "$opt_batch" = 1 ] && [ "$opt_batch_format" = "short" ]; then
+	_echo 0 "${short_output% }"
 fi
 
 if [ "$opt_batch" = 1 ] && [ "$opt_batch_format" = "json" ]; then
@@ -3429,3 +4715,366 @@ fi
 [ "$global_critical" = 1 ] && exit 2  # critical
 [ "$global_unknown"  = 1 ] && exit 3  # unknown
 exit 0  # ok
+
+# We're using MCE.db from the excellent platomav's MCExtractor project
+# The builtin version follows, but the user can download an up-to-date copy (to be stored in his $HOME) by using --update-mcedb
+# To update the builtin version itself (by *modifying* this very file), use --update-builtin-mcedb
+
+# wget https://github.com/platomav/MCExtractor/raw/master/MCE.db
+# sqlite3 MCE.db "select '%%% MCEDB v'||revision||' - '||strftime('%Y/%m/%d', date, 'unixepoch') from MCE; select '# I,0x'||cpuid||',0x'||version||','||max(yyyymmdd) from Intel group by cpuid order by cpuid asc; select '# A,0x'||cpuid||',0x'||version||','||max(yyyymmdd) from AMD group by cpuid order by cpuid asc"
+
+# %%% MCEDB v112 - 2019/05/22
+# I,0x00000611,0x00000B27,19961218
+# I,0x00000612,0x000000C6,19961210
+# I,0x00000616,0x000000C6,19961210
+# I,0x00000617,0x000000C6,19961210
+# I,0x00000619,0x000000D2,19980218
+# I,0x00000630,0x00000013,19960827
+# I,0x00000632,0x00000020,19960903
+# I,0x00000633,0x00000036,19980923
+# I,0x00000634,0x00000037,19980923
+# I,0x00000650,0x00000040,19990525
+# I,0x00000651,0x00000040,19990525
+# I,0x00000652,0x0000002D,19990518
+# I,0x00000653,0x00000010,19990628
+# I,0x00000660,0x0000000A,19990505
+# I,0x00000665,0x00000003,19990505
+# I,0x0000066A,0x0000000C,19990505
+# I,0x0000066D,0x00000007,19990505
+# I,0x00000670,0x00000007,19980602
+# I,0x00000671,0x00000003,19980811
+# I,0x00000672,0x00000010,19990922
+# I,0x00000673,0x0000000E,19990910
+# I,0x00000680,0x00000014,19990610
+# I,0x00000681,0x00000014,19991209
+# I,0x00000683,0x00000013,20010206
+# I,0x00000686,0x00000007,20000505
+# I,0x0000068A,0x00000004,20001207
+# I,0x00000690,0x00000004,20000206
+# I,0x00000691,0x00000001,20020527
+# I,0x00000692,0x00000001,20020620
+# I,0x00000694,0x00000002,20020926
+# I,0x00000695,0x00000007,20041109
+# I,0x00000696,0x00000001,20000707
+# I,0x000006A0,0x00000003,20000110
+# I,0x000006A1,0x00000001,20000306
+# I,0x000006A4,0x00000001,20000616
+# I,0x000006B0,0x0000001A,20010129
+# I,0x000006B1,0x0000001D,20010220
+# I,0x000006B4,0x00000002,20020111
+# I,0x000006D0,0x00000006,20030522
+# I,0x000006D1,0x00000009,20030709
+# I,0x000006D2,0x00000010,20030814
+# I,0x000006D6,0x00000018,20041017
+# I,0x000006D8,0x00000021,20060831
+# I,0x000006E0,0x00000008,20050215
+# I,0x000006E1,0x0000000C,20050413
+# I,0x000006E4,0x00000026,20050816
+# I,0x000006E8,0x0000003C,20060208
+# I,0x000006EC,0x0000005B,20070208
+# I,0x000006F0,0x00000005,20050818
+# I,0x000006F1,0x00000012,20051129
+# I,0x000006F2,0x0000005D,20101002
+# I,0x000006F4,0x00000028,20060417
+# I,0x000006F5,0x00000039,20060727
+# I,0x000006F6,0x000000D2,20101001
+# I,0x000006F7,0x0000006A,20101002
+# I,0x000006F9,0x00000084,20061012
+# I,0x000006FA,0x00000095,20101002
+# I,0x000006FB,0x000000C1,20111004
+# I,0x000006FD,0x000000A4,20101002
+# I,0x00000F00,0xFFFF0001,20000130
+# I,0x00000F01,0xFFFF0007,20000404
+# I,0x00000F02,0xFFFF000B,20000518
+# I,0x00000F03,0xFFFF0001,20000518
+# I,0x00000F04,0xFFFF0010,20000803
+# I,0x00000F05,0x0000000B,20000824
+# I,0x00000F06,0x00000004,20000911
+# I,0x00000F07,0x00000012,20020716
+# I,0x00000F08,0x00000008,20001101
+# I,0x00000F09,0x00000008,20010104
+# I,0x00000F0A,0x00000015,20020821
+# I,0x00000F11,0x0000000A,20030729
+# I,0x00000F12,0x0000002D,20030502
+# I,0x00000F13,0x00000005,20030508
+# I,0x00000F20,0x00000001,20010423
+# I,0x00000F21,0x00000002,20010529
+# I,0x00000F22,0x00000005,20030729
+# I,0x00000F23,0x0000000D,20010817
+# I,0x00000F24,0x00000021,20030610
+# I,0x00000F25,0x0000002C,20040826
+# I,0x00000F26,0x00000010,20040805
+# I,0x00000F27,0x00000038,20030604
+# I,0x00000F29,0x0000002D,20040811
+# I,0x00000F30,0x00000013,20030815
+# I,0x00000F31,0x0000000B,20031021
+# I,0x00000F32,0x0000000A,20040511
+# I,0x00000F33,0x0000000C,20050421
+# I,0x00000F34,0x00000017,20050421
+# I,0x00000F36,0x00000007,20040309
+# I,0x00000F37,0x00000003,20031218
+# I,0x00000F40,0x00000006,20040318
+# I,0x00000F41,0x00000017,20050422
+# I,0x00000F42,0x00000003,20050421
+# I,0x00000F43,0x00000005,20050421
+# I,0x00000F44,0x00000006,20050421
+# I,0x00000F46,0x00000004,20050411
+# I,0x00000F47,0x00000003,20050421
+# I,0x00000F48,0x0000000E,20080115
+# I,0x00000F49,0x00000003,20050421
+# I,0x00000F4A,0x00000004,20051214
+# I,0x00000F60,0x00000005,20050124
+# I,0x00000F61,0x00000008,20050610
+# I,0x00000F62,0x0000000F,20051215
+# I,0x00000F63,0x00000005,20051010
+# I,0x00000F64,0x00000004,20051223
+# I,0x00000F65,0x0000000B,20070510
+# I,0x00000F66,0x0000001B,20060310
+# I,0x00000F68,0x00000009,20060714
+# I,0x00001632,0x00000002,19980610
+# I,0x00010650,0x00000002,20060513
+# I,0x00010660,0x00000004,20060612
+# I,0x00010661,0x00000043,20101004
+# I,0x00010670,0x00000005,20070209
+# I,0x00010671,0x00000106,20070329
+# I,0x00010674,0x84050100,20070726
+# I,0x00010676,0x00000612,20150802
+# I,0x00010677,0x0000070D,20150802
+# I,0x0001067A,0x00000A0E,20150729
+# I,0x000106A0,0xFFFF001A,20071128
+# I,0x000106A1,0xFFFF000B,20080220
+# I,0x000106A2,0xFFFF0019,20080714
+# I,0x000106A4,0x00000013,20150630
+# I,0x000106A5,0x0000001D,20180511
+# I,0x000106C0,0x00000007,20070824
+# I,0x000106C1,0x00000109,20071203
+# I,0x000106C2,0x00000217,20090410
+# I,0x000106C9,0x00000007,20090213
+# I,0x000106CA,0x00000107,20090825
+# I,0x000106D0,0x00000005,20071204
+# I,0x000106D1,0x0000002A,20150803
+# I,0x000106E0,0xFFFF0022,20090116
+# I,0x000106E1,0xFFFF000D,20090206
+# I,0x000106E3,0xFFFF0011,20090512
+# I,0x000106E4,0x00000003,20130701
+# I,0x000106E5,0x0000000A,20180508
+# I,0x000106F0,0xFFFF0009,20090210
+# I,0x000106F1,0xFFFF0007,20090210
+# I,0x00020650,0xFFFF0008,20090218
+# I,0x00020651,0xFFFF0018,20090818
+# I,0x00020652,0x00000011,20180508
+# I,0x00020654,0xFFFF0007,20091124
+# I,0x00020655,0x00000007,20180423
+# I,0x00020661,0x00000105,20110718
+# I,0x000206A0,0x00000029,20091102
+# I,0x000206A1,0x00000007,20091223
+# I,0x000206A2,0x00000027,20100502
+# I,0x000206A3,0x00000009,20100609
+# I,0x000206A4,0x00000022,20100414
+# I,0x000206A5,0x00000007,20100722
+# I,0x000206A6,0x90030028,20100924
+# I,0x000206A7,0x0000002F,20190217
+# I,0x000206C0,0xFFFF001C,20091214
+# I,0x000206C1,0x00000006,20091222
+# I,0x000206C2,0x0000001F,20180508
+# I,0x000206D0,0x80000006,20100816
+# I,0x000206D1,0x80000106,20101201
+# I,0x000206D2,0x9584020C,20110622
+# I,0x000206D3,0x80000304,20110420
+# I,0x000206D5,0x00000513,20111013
+# I,0x000206D6,0x0000061D,20180508
+# I,0x000206D7,0x00000714,20180508
+# I,0x000206E0,0xE3493401,20090108
+# I,0x000206E1,0xE3493402,20090224
+# I,0x000206E2,0xFFFF0004,20081001
+# I,0x000206E3,0xE4486547,20090701
+# I,0x000206E4,0xFFFF0008,20090619
+# I,0x000206E5,0xFFFF0018,20091215
+# I,0x000206E6,0x0000000D,20180515
+# I,0x000206F0,0x00000004,20100630
+# I,0x000206F1,0x00000008,20101013
+# I,0x000206F2,0x0000003B,20180516
+# I,0x00030650,0x00000009,20120118
+# I,0x00030651,0x00000110,20131014
+# I,0x00030660,0x00000003,20101103
+# I,0x00030661,0x0000010F,20150721
+# I,0x00030669,0x0000010D,20130515
+# I,0x00030671,0x00000117,20130410
+# I,0x00030672,0x0000022E,20140401
+# I,0x00030673,0x00000326,20180110
+# I,0x00030678,0x00000838,20190422
+# I,0x00030679,0x0000090C,20190423
+# I,0x000306A0,0x00000007,20110407
+# I,0x000306A2,0x0000000C,20110725
+# I,0x000306A4,0x00000007,20110908
+# I,0x000306A5,0x00000009,20111110
+# I,0x000306A6,0x00000004,20111114
+# I,0x000306A8,0x00000010,20120220
+# I,0x000306A9,0x00000021,20190213
+# I,0x000306C0,0xFFFF0013,20111110
+# I,0x000306C1,0xFFFF0014,20120725
+# I,0x000306C2,0xFFFF0006,20121017
+# I,0x000306C3,0x00000027,20190226
+# I,0x000306D1,0xFFFF0009,20131015
+# I,0x000306D2,0xFFFF0009,20131219
+# I,0x000306D3,0xE3121338,20140825
+# I,0x000306D4,0x0000002D,20190307
+# I,0x000306E0,0x00000008,20120726
+# I,0x000306E2,0x0000020D,20130321
+# I,0x000306E3,0x00000308,20130321
+# I,0x000306E4,0x0000042E,20190314
+# I,0x000306E6,0x00000600,20130619
+# I,0x000306E7,0x00000715,20190314
+# I,0x000306F0,0xFFFF0017,20130730
+# I,0x000306F1,0x00000014,20140110
+# I,0x000306F2,0x00000043,20190301
+# I,0x000306F3,0x0000000D,20160211
+# I,0x000306F4,0x00000014,20190301
+# I,0x00040650,0xFFFF000B,20121206
+# I,0x00040651,0x00000025,20190226
+# I,0x00040660,0xFFFF0011,20121012
+# I,0x00040661,0x0000001B,20190226
+# I,0x00040670,0xFFFF0006,20140304
+# I,0x00040671,0x00000020,20190307
+# I,0x000406A0,0x80124001,20130521
+# I,0x000406A8,0x0000081F,20140812
+# I,0x000406A9,0x0000081F,20140812
+# I,0x000406C1,0x0000010B,20140814
+# I,0x000406C2,0x00000221,20150218
+# I,0x000406C3,0x00000368,20190423
+# I,0x000406C4,0x00000411,20190423
+# I,0x000406D0,0x0000000E,20130612
+# I,0x000406D8,0x0000012A,20180104
+# I,0x000406E1,0x00000020,20141111
+# I,0x000406E2,0x0000002C,20150521
+# I,0x000406E3,0x000000CC,20190401
+# I,0x000406E8,0x00000026,20160414
+# I,0x000406F0,0x00000014,20150702
+# I,0x000406F1,0x0B000036,20190302
+# I,0x00050650,0x8000002B,20160208
+# I,0x00050651,0x8000002B,20160208
+# I,0x00050652,0x80000037,20170502
+# I,0x00050653,0x01000146,20180824
+# I,0x00050654,0x0200005E,20190402
+# I,0x00050655,0x03000010,20181116
+# I,0x00050656,0x04000024,20190407
+# I,0x00050657,0x05000024,20190407
+# I,0x00050661,0xF1000008,20150130
+# I,0x00050662,0x0000001A,20190323
+# I,0x00050663,0x07000017,20190323
+# I,0x00050664,0x0F000015,20190323
+# I,0x00050665,0x0E00000D,20190323
+# I,0x00050670,0xFFFF0030,20151113
+# I,0x00050671,0x000001B6,20180108
+# I,0x000506A0,0x00000038,20150112
+# I,0x000506C2,0x00000014,20180511
+# I,0x000506C8,0x90011010,20160323
+# I,0x000506C9,0x00000038,20190115
+# I,0x000506CA,0x00000016,20190301
+# I,0x000506D1,0x00000102,20150605
+# I,0x000506E0,0x00000018,20141119
+# I,0x000506E1,0x0000002A,20150602
+# I,0x000506E2,0x0000002E,20150815
+# I,0x000506E3,0x000000CC,20190401
+# I,0x000506E8,0x00000034,20160710
+# I,0x000506F0,0x00000010,20160607
+# I,0x000506F1,0x0000002E,20190321
+# I,0x00060660,0x0000000C,20160821
+# I,0x00060661,0x0000000E,20170128
+# I,0x00060662,0x00000022,20171129
+# I,0x00060663,0x0000002A,20180417
+# I,0x000706A0,0x00000026,20170712
+# I,0x000706A1,0x0000002E,20190102
+# I,0x000706E0,0x0000002A,20180528
+# I,0x000706E1,0x00000040,20190327
+# I,0x000706E2,0x00000040,20190327
+# I,0x000706E4,0x0000001A,20190403
+# I,0x000706E5,0x0000001E,20190420
+# I,0x00080650,0x00000018,20180108
+# I,0x000806E9,0x000000B4,20190401
+# I,0x000806EA,0x000000B4,20190401
+# I,0x000806EB,0x000000B8,20190330
+# I,0x000806EC,0x000000B8,20190330
+# I,0x000906E9,0x000000B4,20190401
+# I,0x000906EA,0x000000B4,20190401
+# I,0x000906EB,0x000000B4,20190401
+# I,0x000906EC,0x000000AE,20190214
+# I,0x000906ED,0x000000BC,20190513
+# A,0x00000F00,0x02000008,20070614
+# A,0x00000F01,0x0000001C,20021031
+# A,0x00000F10,0x00000003,20020325
+# A,0x00000F11,0x0000001F,20030220
+# A,0x00000F48,0x00000046,20040719
+# A,0x00000F4A,0x00000047,20040719
+# A,0x00000F50,0x00000024,20021212
+# A,0x00000F51,0x00000025,20030115
+# A,0x00010F50,0x00000041,20040225
+# A,0x00020F10,0x0000004D,20050428
+# A,0x00040F01,0xC0012102,20050916
+# A,0x00040F0A,0x00000068,20060920
+# A,0x00040F13,0x0000007A,20080508
+# A,0x00040F14,0x00000062,20060127
+# A,0x00040F1B,0x0000006D,20060920
+# A,0x00040F33,0x0000007B,20080514
+# A,0x00060F80,0x00000083,20060929
+# A,0x000C0F1B,0x0000006E,20060921
+# A,0x000F0F00,0x00000005,20020627
+# A,0x000F0F01,0x00000015,20020627
+# A,0x00100F00,0x01000020,20070326
+# A,0x00100F20,0x010000CA,20100331
+# A,0x00100F22,0x010000C9,20100331
+# A,0x00100F40,0x01000085,20080501
+# A,0x00100F41,0x010000DB,20111024
+# A,0x00100F42,0x01000092,20081021
+# A,0x00100F43,0x010000C8,20100311
+# A,0x00100F62,0x010000C7,20100311
+# A,0x00100F80,0x010000DA,20111024
+# A,0x00100F81,0x010000D9,20111012
+# A,0x00100FA0,0x010000DC,20111024
+# A,0x00120F00,0x03000002,20100324
+# A,0x00200F30,0x02000018,20070921
+# A,0x00200F31,0x02000057,20080502
+# A,0x00200F32,0x02000034,20080307
+# A,0x00300F01,0x0300000E,20101004
+# A,0x00300F10,0x03000027,20111309
+# A,0x00500F00,0x0500000B,20100601
+# A,0x00500F01,0x0500001A,20100908
+# A,0x00500F10,0x05000029,20130121
+# A,0x00500F20,0x05000119,20130118
+# A,0x00580F00,0x0500000B,20100601
+# A,0x00580F01,0x0500001A,20100908
+# A,0x00580F10,0x05000028,20101124
+# A,0x00580F20,0x05000101,20110406
+# A,0x00600F00,0x06000017,20101029
+# A,0x00600F01,0x0600011F,20110227
+# A,0x00600F10,0x06000425,20110408
+# A,0x00600F11,0x0600050D,20110627
+# A,0x00600F12,0x0600063E,20180207
+# A,0x00600F20,0x06000852,20180206
+# A,0x00610F00,0x0600100E,20111102
+# A,0x00610F01,0x0600111F,20180305
+# A,0x00630F00,0x0600301C,20130817
+# A,0x00630F01,0x06003109,20180227
+# A,0x00660F00,0x06006012,20141014
+# A,0x00660F01,0x0600611A,20180126
+# A,0x00670F00,0x06006705,20180220
+# A,0x00680F00,0x06000017,20101029
+# A,0x00680F01,0x0600011F,20110227
+# A,0x00680F10,0x06000410,20110314
+# A,0x00700F00,0x0700002A,20121218
+# A,0x00700F01,0x07000110,20180209
+# A,0x00730F00,0x07030009,20131206
+# A,0x00730F01,0x07030106,20180209
+# A,0x00800F00,0x0800002A,20161006
+# A,0x00800F10,0x0800100C,20170131
+# A,0x00800F11,0x08001138,20190204
+# A,0x00800F12,0x08001230,20180804
+# A,0x00800F82,0x0800820C,20190204
+# A,0x00810F00,0x08100004,20161120
+# A,0x00810F10,0x08101014,20190307
+# A,0x00810F11,0x08101102,20181106
+# A,0x00810F80,0x08108002,20180605
+# A,0x00810F81,0x08108102,20180813
+# A,0x00820F00,0x08200002,20180214
+# A,0x00870F00,0x08700004,20181206
+# A,0x00870F10,0x08701011,20190415

--- a/metadata.json
+++ b/metadata.json
@@ -1,14 +1,12 @@
 {
   "name": "timidri-meltdown",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "author": "Dimitri Tischenko & Kevin Reeuwijk",
   "summary": "Detect and remediate Meltdown / Spectre vulnerability",
   "license": "Apache-2.0",
   "source": "https://github.com/timidri/puppet-meltdown",
   "issues_url": "https://github.com/timidri/puppet-meltdown/issues",
-  "dependencies": [
-
-  ],
+  "dependencies": [],
   "operatingsystem_support": [
     {
       "operatingsystem": "CentOS",

--- a/tasks/linux_update.json
+++ b/tasks/linux_update.json
@@ -5,11 +5,11 @@
   "parameters": {
     "force": {
       "description": "If true, the linux kernel update is performed, otherwise the output of what would be updated is printed",
-      "type": "Enum['true', 'false']"
+      "type": "Boolean"
      },
      "reboot": {
       "description": "If true, the system is rebooted after the update is performed, but only if force is also true",
-      "type": "Enum['true', 'false']"
+      "type": "Boolean"
      }
   }
 }

--- a/tasks/windows_update.json
+++ b/tasks/windows_update.json
@@ -5,15 +5,15 @@
   "parameters": {
     "force": {
       "description": "If true, the windows update is performed, otherwise the output of what would be updated is printed",
-      "type": "Enum['true', 'false']"
+      "type": "Boolean"
     },
     "reboot": {
       "description": "If true, the system is rebooted after the update is performed, but only if force is also true",
-      "type": "Enum['true', 'false']"
+      "type": "Boolean"
     },
     "fallbacktowu": {
       "description": "If true, updates can be retrieved from Windows Update directly if they are not provided by the WSUS server",
-      "type": "Enum['true', 'false']"
+      "type": "Boolean"
     }
   }
 }


### PR DESCRIPTION
- Updated spectre_meltdown_checker.sh to v0.42
- Changed param type from Enum to Boolean
- Updated README with current lists of vulnerabilities detected